### PR TITLE
Configure public npm publishing and trusted releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,12 +11,14 @@ jobs:
   release-stable:
     runs-on: ubuntu-24.04
     name: Release Stable
+    env:
+      NPM_CONFIG_PROVENANCE: "true"
     permissions:
       contents: write
       id-token: write # Needed for npm trusted publishing
       pull-requests: write
     outputs:
-      published: ${{ env.PUBLISHED == 'true' }}
+      published: ${{ steps.changesets.outputs.published }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v6
@@ -48,19 +50,21 @@ jobs:
 
       - name: Get current package version
         id: get_version
-        run: echo "CURRENT_PACKAGE_VERSION=$(node -p "require('./packages/identity-common/package.json').version")" >> $GITHUB_ENV
+        run: echo "current_package_version=$(node -p "require('./packages/identity-common/package.json').version")" >> $GITHUB_OUTPUT
 
       - name: Create Github Release
         if: "startsWith(github.event.head_commit.message, 'chore(release): new version')"
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: v${{ env.CURRENT_PACKAGE_VERSION }}
+          tag_name: v${{ steps.get_version.outputs.current_package_version }}
 
   release-unstable:
     runs-on: ubuntu-24.04
     name: Release Unstable
     needs: release-stable
     if: always() && github.event_name == 'push' && needs.release-stable.outputs.published == 'false'
+    env:
+      NPM_CONFIG_PROVENANCE: "true"
     permissions:
       contents: write
       id-token: write # Needed for npm trusted publishing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,8 @@ From the root of the repository:
 | `pnpm style:fix` | Fix code style issues |
 | `pnpm md:check` | Check markdown files |
 | `pnpm md:fix` | Fix markdown issues |
+| `pnpm create-package <name> [--eudi]` | Scaffold a new package |
+| `pnpm npm:trust:bootstrap` | Configure npm trusted publishing for existing packages |
 
 ### Working on a Package
 
@@ -113,11 +115,18 @@ From the root of the repository:
 
 Follow these steps to add a new package to the monorepo:
 
-### 1. Create the Package Directory
+### 1. Scaffold the Package
+
+Prefer the package generator:
 
 ```bash
-mkdir -p packages/my-package/src
+pnpm create-package my-package
+pnpm create-package eudi-example --eudi
 ```
+
+This creates the package directory, `package.json`, `tsconfig.json`, `README.md`, and starter test files with the repository defaults.
+
+If you need to create a package manually, follow the steps below.
 
 ### 2. Create `package.json`
 
@@ -138,6 +147,7 @@ Create `packages/my-package/package.json`:
     "directory": "packages/my-package"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
@@ -392,12 +402,25 @@ When adding a new package to the monorepo:
 
    You must be logged into npm (`npm login`) with an account that has publish access to the `@owf` scope.
 
-3. **Configure trusted publishing on npmjs.com:**
+3. **Configure trusted publishing once:**
+
+   Preferred: run the repository bootstrap script from the repo root:
+
+   ```bash
+   pnpm npm:trust:bootstrap
+   ```
+
+   This configures each published workspace package to trust the GitHub Actions release workflow (`release.yml`).
+
+   Alternatively, you can configure the package manually on npmjs.com:
+
    - Go to `https://www.npmjs.com/package/@owf/your-new-package/access`
    - In the "Trusted Publisher" section, configure:
      - **Organization**: `openwallet-foundation-labs`
      - **Repository**: `identity-common-ts`
      - **Workflow filename**: `release.yml`
+
+   `npm trust` only works after the package already exists on npm.
 
 4. **Future releases are automatic** - CI will handle all subsequent publishes via trusted publishing.
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "build": "pnpm -r build",
     "test": "vitest",
     "create-package": "node scripts/create-package.mjs",
+    "npm:trust:bootstrap": "bash scripts/npm-trust-bootstrap.sh",
     "release": "pnpm build && pnpm changeset publish --no-git-tag 2>&1 | tee changeset-publish.log",
     "changeset-version": "pnpm changeset version && pnpm style:fix",
     "prepare": "husky"

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -13,6 +13,7 @@
     "directory": "packages/crypto"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/eudi-attestation-schema/package.json
+++ b/packages/eudi-attestation-schema/package.json
@@ -15,6 +15,7 @@
     "directory": "packages/eudi-attestation-schema"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/eudi-lote/package.json
+++ b/packages/eudi-lote/package.json
@@ -14,6 +14,7 @@
     "directory": "packages/eudi-lote"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/eudi-sca/package.json
+++ b/packages/eudi-sca/package.json
@@ -14,6 +14,7 @@
     "directory": "packages/eudi-sca"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/eudi-wrprc/package.json
+++ b/packages/eudi-wrprc/package.json
@@ -24,6 +24,7 @@
     "identity"
   ],
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/identity-common/package.json
+++ b/packages/identity-common/package.json
@@ -13,6 +13,7 @@
     "directory": "packages/identity-common"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/packages/token-status-list/package.json
+++ b/packages/token-status-list/package.json
@@ -13,6 +13,7 @@
     "directory": "packages/token-status-list"
   },
   "publishConfig": {
+    "access": "public",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {

--- a/scripts/create-package.mjs
+++ b/scripts/create-package.mjs
@@ -56,6 +56,7 @@ const packageJson = {
     directory: `packages/${packageName}`,
   },
   publishConfig: {
+    access: 'public',
     module: './dist/index.mjs',
     types: './dist/index.d.mts',
     exports: {

--- a/scripts/npm-trust-bootstrap.sh
+++ b/scripts/npm-trust-bootstrap.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# One-time setup for npm trusted publishing in a workspace.
+# This configures each package to trust a GitHub Actions workflow.
+#
+# Usage:
+#   bash scripts/npm-trust-bootstrap.sh
+#   REPO=openwallet-foundation-labs/identity-common-ts bash scripts/npm-trust-bootstrap.sh
+#   WORKFLOW_FILE=release.yml bash scripts/npm-trust-bootstrap.sh
+#   ENVIRONMENT=production bash scripts/npm-trust-bootstrap.sh
+#
+# Requirements:
+# - npm >= 11.10
+# - write access to each npm package
+# - 2FA enabled on your npm account
+# - package already exists on npm
+
+REPO="${REPO:-openwallet-foundation-labs/identity-common-ts}"
+WORKFLOW_FILE="${WORKFLOW_FILE:-release.yml}"
+ENVIRONMENT="${ENVIRONMENT:-}"
+
+if [[ ! -f package.json ]]; then
+  echo "Run this script from the repository root."
+  exit 1
+fi
+
+if [[ ! -d packages ]]; then
+  echo "Missing packages directory."
+  exit 1
+fi
+
+npm_version_raw="$(npm --version)"
+npm_major="${npm_version_raw%%.*}"
+if (( npm_major < 11 )); then
+  echo "npm >= 11 is required for npm trust (found ${npm_version_raw})."
+  exit 1
+fi
+
+echo "Repository: ${REPO}"
+echo "Workflow file: ${WORKFLOW_FILE}"
+if [[ -n "${ENVIRONMENT}" ]]; then
+  echo "Environment: ${ENVIRONMENT}"
+fi
+
+echo
+echo "Configuring npm trusted publishing for workspace packages..."
+
+for package_file in packages/*/package.json; do
+  pkg_name="$(jq -r '.name' "${package_file}")"
+
+  if [[ -z "${pkg_name}" || "${pkg_name}" == "null" ]]; then
+    echo "Skipping ${package_file}: missing package name"
+    continue
+  fi
+
+  echo
+  echo "Package: ${pkg_name}"
+
+  trust_count="$(npm trust list "${pkg_name}" --json 2>/dev/null | jq 'length' 2>/dev/null || echo 0)"
+  if [[ "${trust_count}" != "0" ]]; then
+    echo "Already configured, skipping."
+    continue
+  fi
+
+  cmd=(npm trust github "${pkg_name}" --repo "${REPO}" --file "${WORKFLOW_FILE}" --yes)
+  if [[ -n "${ENVIRONMENT}" ]]; then
+    cmd+=(--environment "${ENVIRONMENT}")
+  fi
+
+  echo "Running: ${cmd[*]}"
+  "${cmd[@]}"
+done
+
+echo
+echo "Done. Verify with: npm trust list <package-name>"


### PR DESCRIPTION
## Summary

This PR aligns package publishing and release automation across the monorepo.

- set `publishConfig.access` to `public` for all publishable packages
- update the package generator so new packages inherit public publish access
- add a one-time `npm:trust:bootstrap` helper for configuring npm trusted publishing
- document the package scaffolding and trusted publishing workflow in `CONTRIBUTING.md`
- fix the release workflow to use valid step outputs and enable npm provenance in CI

## Why

New packages need an initial public publish and a one-time trusted publisher configuration before CI can release them via OIDC. These changes make that workflow explicit and keep future packages consistent.

## Validation

- verified all package manifests now set `publishConfig.access` to `public`
- validated `CONTRIBUTING.md` with `markdownlint-cli2`
- checked the release workflow for editor diagnostics after the output fixes
