### PR TITLE
docs(changeset): Also include commonjs builds

### DIFF
--- a/.changeset/ripe-deserts-heal.md
+++ b/.changeset/ripe-deserts-heal.md
@@ -1,0 +1,11 @@
+---
+"@owf/eudi-attestation-schema": patch
+"@owf/token-status-list": patch
+"@owf/identity-common": patch
+"@owf/eudi-wrprc": patch
+"@owf/eudi-lote": patch
+"@owf/eudi-sca": patch
+"@owf/crypto": patch
+---
+
+Also include commonjs builds

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -14,15 +14,21 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",

--- a/packages/eudi-attestation-schema/package.json
+++ b/packages/eudi-attestation-schema/package.json
@@ -16,10 +16,16 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
@@ -34,7 +40,7 @@
     "ts11"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",

--- a/packages/eudi-lote/package.json
+++ b/packages/eudi-lote/package.json
@@ -15,10 +15,16 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
@@ -33,7 +39,7 @@
     "jwt"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",

--- a/packages/eudi-sca/package.json
+++ b/packages/eudi-sca/package.json
@@ -15,10 +15,16 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
@@ -29,7 +35,7 @@
     "wallet"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "@openid4vc/openid4vci": "0.5.0-alpha-20260415063740",

--- a/packages/eudi-wrprc/package.json
+++ b/packages/eudi-wrprc/package.json
@@ -25,15 +25,21 @@
   ],
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",

--- a/packages/identity-common/package.json
+++ b/packages/identity-common/package.json
@@ -14,14 +14,20 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   }
 }

--- a/packages/token-status-list/package.json
+++ b/packages/token-status-list/package.json
@@ -14,15 +14,21 @@
   },
   "publishConfig": {
     "access": "public",
+    "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.mts",
     "exports": {
-      ".": "./dist/index.mjs",
+      ".": {
+        "types": "./dist/index.d.mts",
+        "import": "./dist/index.mjs",
+        "require": "./dist/index.cjs",
+        "default": "./dist/index.mjs"
+      },
       "./package.json": "./package.json"
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
   },
   "dependencies": {
     "cbor-x": "^1.6.4",


### PR DESCRIPTION
## Description

Add commonjs build to output, while esm is still the default. Relevant for backends that still rely in commonjs like nestjs

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

all