### PR TITLE
feat: easier filtering in the API for preferred locales

### DIFF
--- a/packages/eudi-sca/src/__tests__/transactionData.test.ts
+++ b/packages/eudi-sca/src/__tests__/transactionData.test.ts
@@ -90,4 +90,50 @@ suite('transaction data', () => {
     invalidCm.transaction_data_types['urn:eudi:sca:com.example.pay:transaction:2'].claims[0].display = undefined
     expect(() => matchTransactionDataToTransactionDataType([TRANSACTION_DATA[0]], invalidCm)).toThrow()
   })
+
+  test('match transaction data with credential metadata using preferred locale', () => {
+    const parsed = matchTransactionDataToTransactionDataType([TRANSACTION_DATA[0]], credential_metadata, 'de')
+
+    expect(parsed).toMatchObject({
+      'urn:eudi:sca:com.example.pay:transaction:2': {
+        transaction_id: { value: 'ab9c4d5e-6f78-9012-3456-789abcdef012' },
+        amount: {
+          valueType: 'iso_currency_amount',
+          value: '49.99 EUR',
+          display: [{ locale: 'de', name: 'betrag' }],
+        },
+        name: {
+          value: 'Example Shop',
+          display: [{ locale: 'de', name: 'empfänger' }],
+        },
+        id: { value: 'DE98ZZZ09999999999' },
+      },
+    })
+  })
+
+  test('match transaction data with credential metadata using non-existent locale', () => {
+    const parsed = matchTransactionDataToTransactionDataType([TRANSACTION_DATA[0]], credential_metadata, 'fr')
+
+    expect(parsed).toMatchObject({
+      'urn:eudi:sca:com.example.pay:transaction:2': {
+        transaction_id: { value: 'ab9c4d5e-6f78-9012-3456-789abcdef012' },
+        amount: {
+          valueType: 'iso_currency_amount',
+          value: '49.99 EUR',
+          display: [
+            { locale: 'en', name: 'amount' },
+            { locale: 'de', name: 'betrag' },
+          ],
+        },
+        name: {
+          value: 'Example Shop',
+          display: [
+            { locale: 'en', name: 'payee' },
+            { locale: 'de', name: 'empfänger' },
+          ],
+        },
+        id: { value: 'DE98ZZZ09999999999' },
+      },
+    })
+  })
 })

--- a/packages/eudi-sca/src/transactionData.ts
+++ b/packages/eudi-sca/src/transactionData.ts
@@ -35,7 +35,8 @@ export type PayloadWithDisplayInfo = Record<
 
 const __matchTransactionDataToTransactionDataType = (
   transactionData: Array<TransactionData>,
-  credentialMetadata: CredentialMetadata
+  credentialMetadata: CredentialMetadata,
+  preferredLocale?: string
 ): Record<string, PayloadWithDisplayInfo> => {
   const transactionDataTypes = Object.entries(credentialMetadata.transaction_data_types).reduce<
     CredentialMetadata['transaction_data_types']
@@ -66,10 +67,14 @@ const __matchTransactionDataToTransactionDataType = (
         const shouldBeAdded = mandatory ? mandatory === isValid : isValid
 
         if (shouldBeAdded) {
+          const preferredDisplay = preferredLocale
+            ? display?.find(({ locale }) => locale === preferredLocale)
+            : undefined
+
           prev[jsonPathValueAndKey.key] = {
             valueType: value_type,
             value: jsonPathValueAndKey.value,
-            display,
+            display: preferredDisplay ? [preferredDisplay] : display,
           }
         }
         return prev
@@ -110,7 +115,8 @@ const __matchTransactionDataToTransactionDataType = (
 
 export const matchTransactionDataToTransactionDataType = (
   transactionData: Array<string>,
-  credentialMetadata: Record<string, unknown>
+  credentialMetadata: Record<string, unknown>,
+  preferredLocale?: string
 ) => {
   const parsedTransactionData = transactionData
     .map((td) => {
@@ -122,7 +128,7 @@ export const matchTransactionDataToTransactionDataType = (
     })
     .filter((td) => td !== undefined)
   const parsedCredentialMetadata = parseCredentialMetadata(credentialMetadata)
-  return __matchTransactionDataToTransactionDataType(parsedTransactionData, parsedCredentialMetadata)
+  return __matchTransactionDataToTransactionDataType(parsedTransactionData, parsedCredentialMetadata, preferredLocale)
 }
 
 const matchValueTypeToValue = (valueType: ValueType | string, value: unknown) => {


### PR DESCRIPTION

## Description

Add a way to prefilter all locales so displaying becomes easier

## Related Issue


Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/eudi-sca`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)
