### PR TITLE
fix: remove redundant SchemaMeta supportedFormats

### DIFF
--- a/.changeset/chilly-colts-nail.md
+++ b/.changeset/chilly-colts-nail.md
@@ -1,0 +1,5 @@
+---
+"@owf/eudi-attestation-schema": patch
+---
+
+remove redundant format info

--- a/packages/eudi-attestation-schema/README.md
+++ b/packages/eudi-attestation-schema/README.md
@@ -49,7 +49,6 @@ const meta = schemaMeta()
   )
   .attestationLoS('iso_18045_basic')
   .bindingType('key')
-  .addFormat('dc+sd-jwt')
   .addSchemaURI(
     schemaURI()
       .format('dc+sd-jwt')
@@ -93,7 +92,6 @@ const meta = schemaMeta()
   .rulebookURI('https://example.com/rulebook.md')
   .attestationLoS('iso_18045_basic')
   .bindingType('key')
-  .addFormat('dc+sd-jwt')
   .addSchemaURI(
     schemaURI()
       .format('dc+sd-jwt')
@@ -143,7 +141,6 @@ console.log(header.kid);      // 'catalog-signer-2025'
 | `trustedAuthorities` | No | `TrustAuthority[]` | Trust anchors for attestation issuers |
 | `attestationLoS` | Yes | `AttestationLoS` | Level of security |
 | `bindingType` | Yes | `BindingType` | Cryptographic binding type |
-| `supportedFormats` | Yes | `AttestationFormat[]` | Supported attestation formats |
 | `schemaURIs` | Yes | `SchemaURI[]` | Schema URIs per format |
 
 ### Enumerations

--- a/packages/eudi-attestation-schema/examples/sign-and-verify.ts
+++ b/packages/eudi-attestation-schema/examples/sign-and-verify.ts
@@ -51,8 +51,6 @@ async function main() {
     .rulebookURI('https://legislation.example.eu/eidas2/pid-rulebook')
     .attestationLoS('iso_18045_basic')
     .bindingType('key')
-    .addFormat('dc+sd-jwt')
-    .addFormat('mso_mdoc')
     .addSchemaURI(
       schemaURI().format('dc+sd-jwt').uri('https://catalog.example.com/schemas/pid/sd-jwt/1.0.0.json').build()
     )

--- a/packages/eudi-attestation-schema/src/__tests__/builders.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/builders.test.mts
@@ -92,7 +92,6 @@ describe('SchemaMetaBuilder', () => {
       .rulebookURI('https://example.com/rulebook.md')
       .attestationLoS('iso_18045_basic')
       .bindingType('key')
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
       .build()
 
@@ -100,7 +99,6 @@ describe('SchemaMetaBuilder', () => {
     expect(meta.rulebookURI).toBe('https://example.com/rulebook.md')
     expect(meta.attestationLoS).toBe('iso_18045_basic')
     expect(meta.bindingType).toBe('key')
-    expect(meta.supportedFormats).toEqual(['dc+sd-jwt'])
     expect(meta.schemaURIs).toHaveLength(1)
   })
 
@@ -119,7 +117,6 @@ describe('SchemaMetaBuilder', () => {
       .addTrustAuthority(ta)
       .attestationLoS('iso_18045_basic')
       .bindingType('key')
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(
         schemaURI()
           .format('dc+sd-jwt')
@@ -143,28 +140,25 @@ describe('SchemaMetaBuilder', () => {
       .rulebookURI('https://example.com/rulebook.md')
       .attestationLoS('iso_18045_high')
       .bindingType('claim')
-      .addFormat('dc+sd-jwt')
-      .addFormat('mso_mdoc')
       .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema-sdjwt.json').build())
       .addSchemaURI(schemaURI().format('mso_mdoc').uri('https://example.com/schema-mdoc.json').build())
       .build()
 
-    expect(meta.supportedFormats).toEqual(['dc+sd-jwt', 'mso_mdoc'])
+    expect(meta.schemaURIs.map((schema) => schema.formatIdentifier)).toEqual(['dc+sd-jwt', 'mso_mdoc'])
     expect(meta.schemaURIs).toHaveLength(2)
   })
 
-  it('should not add duplicate formats', () => {
+  it('should allow duplicate format identifiers across schema URIs', () => {
     const meta = schemaMeta()
       .version('1.0.0')
       .rulebookURI('https://example.com/rulebook.md')
       .attestationLoS('iso_18045_basic')
       .bindingType('none')
-      .addFormat('dc+sd-jwt')
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
+      .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema-v2.json').build())
       .build()
 
-    expect(meta.supportedFormats).toEqual(['dc+sd-jwt'])
+    expect(meta.schemaURIs).toHaveLength(2)
   })
 
   it('should support multiple trust authorities', () => {
@@ -175,7 +169,6 @@ describe('SchemaMetaBuilder', () => {
       .bindingType('key')
       .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://example.com/tl1.jws').build())
       .addTrustAuthority(trustAuthority().frameworkType('aki').value('dGVzdA').build())
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
       .build()
 
@@ -188,7 +181,6 @@ describe('SchemaMetaBuilder', () => {
         .rulebookURI('https://example.com/rulebook.md')
         .attestationLoS('iso_18045_basic')
         .bindingType('key')
-        .addFormat('dc+sd-jwt')
         .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
         .build()
     }).toThrow('Invalid SchemaMeta')
@@ -198,19 +190,6 @@ describe('SchemaMetaBuilder', () => {
     expect(() => {
       schemaMeta()
         .version('1.0.0')
-        .attestationLoS('iso_18045_basic')
-        .bindingType('key')
-        .addFormat('dc+sd-jwt')
-        .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
-        .build()
-    }).toThrow('Invalid SchemaMeta')
-  })
-
-  it('should throw when supportedFormats is empty', () => {
-    expect(() => {
-      schemaMeta()
-        .version('1.0.0')
-        .rulebookURI('https://example.com/rulebook.md')
         .attestationLoS('iso_18045_basic')
         .bindingType('key')
         .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
@@ -225,7 +204,6 @@ describe('SchemaMetaBuilder', () => {
         .rulebookURI('https://example.com/rulebook.md')
         .attestationLoS('iso_18045_basic')
         .bindingType('key')
-        .addFormat('dc+sd-jwt')
         .build()
     }).toThrow('Invalid SchemaMeta')
   })
@@ -247,7 +225,6 @@ describe('SchemaMetaBuilder', () => {
       )
       .attestationLoS('iso_18045_basic')
       .bindingType('key')
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(
         schemaURI()
           .format('dc+sd-jwt')
@@ -263,7 +240,6 @@ describe('SchemaMetaBuilder', () => {
     expect(meta.version).toBe('1.0.0')
     expect(meta.trustedAuthorities).toHaveLength(1)
     expect(meta.trustedAuthorities?.[0].isLOTE).toBe(true)
-    expect(meta.supportedFormats).toEqual(['dc+sd-jwt'])
     expect(meta.schemaURIs).toHaveLength(1)
   })
 })

--- a/packages/eudi-attestation-schema/src/__tests__/signer.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/signer.test.mts
@@ -39,7 +39,6 @@ describe('signSchemaMeta', () => {
       .rulebookURI('https://example.com/rulebook.md')
       .attestationLoS('iso_18045_basic')
       .bindingType('key')
-      .addFormat('dc+sd-jwt')
       .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
       .build()
 
@@ -94,7 +93,6 @@ describe('signSchemaMeta', () => {
     expect(decoded.version).toBe('1.0.0')
     expect(decoded.rulebookURI).toBe('https://example.com/rulebook.md')
     expect(decoded.attestationLoS).toBe('iso_18045_basic')
-    expect(decoded.supportedFormats).toEqual(['dc+sd-jwt'])
     expect(decoded.iat).toBeTypeOf('number')
   })
 

--- a/packages/eudi-attestation-schema/src/__tests__/validator.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/validator.test.mts
@@ -6,7 +6,6 @@ const validSchemaMeta = {
   rulebookURI: 'https://example.com/rulebook.md',
   attestationLoS: 'iso_18045_basic',
   bindingType: 'key',
-  supportedFormats: ['dc+sd-jwt'],
   schemaURIs: [
     {
       formatIdentifier: 'dc+sd-jwt',
@@ -62,16 +61,6 @@ describe('validateSchemaMeta', () => {
     expect(result.valid).toBe(false)
   })
 
-  it('should reject invalid supportedFormats value', () => {
-    const result = validateSchemaMeta({ ...validSchemaMeta, supportedFormats: ['invalid_format'] })
-    expect(result.valid).toBe(false)
-  })
-
-  it('should reject empty supportedFormats', () => {
-    const result = validateSchemaMeta({ ...validSchemaMeta, supportedFormats: [] })
-    expect(result.valid).toBe(false)
-  })
-
   it('should reject empty schemaURIs', () => {
     const result = validateSchemaMeta({ ...validSchemaMeta, schemaURIs: [] })
     expect(result.valid).toBe(false)
@@ -118,6 +107,6 @@ describe('assertValidSchemaMeta', () => {
     assertValidSchemaMeta(data)
     // After assertion, data should be typed as SchemaMeta
     expect(data.version).toBe('1.0.0')
-    expect(data.supportedFormats).toContain('dc+sd-jwt')
+    expect(data.schemaURIs[0].formatIdentifier).toBe('dc+sd-jwt')
   })
 })

--- a/packages/eudi-attestation-schema/src/__tests__/verifier.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/verifier.test.mts
@@ -38,7 +38,6 @@ const buildTestMeta = () =>
     .rulebookURI('https://example.com/rulebook.md')
     .attestationLoS('iso_18045_basic')
     .bindingType('key')
-    .addFormat('dc+sd-jwt')
     .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
     .build()
 

--- a/packages/eudi-attestation-schema/src/builders.ts
+++ b/packages/eudi-attestation-schema/src/builders.ts
@@ -1,14 +1,6 @@
 import { SchemaMetaException } from './schema-meta-exception'
 import { SchemaMetaSchema, SchemaURISchema, TrustAuthoritySchema } from './schemas'
-import type {
-  AttestationFormat,
-  AttestationLoS,
-  BindingType,
-  FrameworkType,
-  SchemaMeta,
-  SchemaURI,
-  TrustAuthority,
-} from './types'
+import type { AttestationLoS, BindingType, FrameworkType, SchemaMeta, SchemaURI, TrustAuthority } from './types'
 
 /**
  * Builder for creating TrustAuthority objects with a fluent API
@@ -160,17 +152,6 @@ export class SchemaMetaBuilder {
    */
   bindingType(type: BindingType): this {
     this.data.bindingType = type
-    return this
-  }
-
-  /**
-   * Add a supported attestation format
-   */
-  addFormat(format: AttestationFormat): this {
-    this.data.supportedFormats = this.data.supportedFormats ?? []
-    if (!this.data.supportedFormats.includes(format)) {
-      this.data.supportedFormats.push(format)
-    }
     return this
   }
 

--- a/packages/eudi-attestation-schema/src/builders.ts
+++ b/packages/eudi-attestation-schema/src/builders.ts
@@ -1,6 +1,14 @@
 import { SchemaMetaException } from './schema-meta-exception'
 import { SchemaMetaSchema, SchemaURISchema, TrustAuthoritySchema } from './schemas'
-import type { AttestationLoS, BindingType, FrameworkType, SchemaMeta, SchemaURI, TrustAuthority } from './types'
+import type {
+  AttestationFormat,
+  AttestationLoS,
+  BindingType,
+  FrameworkType,
+  SchemaMeta,
+  SchemaURI,
+  TrustAuthority,
+} from './types'
 
 /**
  * Builder for creating TrustAuthority objects with a fluent API

--- a/packages/eudi-attestation-schema/src/schemas.ts
+++ b/packages/eudi-attestation-schema/src/schemas.ts
@@ -78,6 +78,5 @@ export const SchemaMetaSchema = z.object({
   trustedAuthorities: z.array(TrustAuthoritySchema).optional(),
   attestationLoS: AttestationLoSSchema,
   bindingType: BindingTypeSchema,
-  supportedFormats: z.array(AttestationFormatSchema).min(1),
   schemaURIs: z.array(SchemaURISchema).min(1),
 })

--- a/packages/eudi-attestation-schema/src/signer.ts
+++ b/packages/eudi-attestation-schema/src/signer.ts
@@ -21,7 +21,6 @@ import type { SignedSchemaMeta, SignOptions } from './types'
  *   .rulebookURI('https://example.com/rulebook.md')
  *   .attestationLoS('iso_18045_basic')
  *   .bindingType('key')
- *   .addFormat('dc+sd-jwt')
  *   .addSchemaURI(schemaURI().format('dc+sd-jwt').uri('https://example.com/schema.json').build())
  *   .build()
  *


### PR DESCRIPTION
## Description

Removes the redundant `supportedFormats` field from SchemaMeta and uses `schemaURIs[].formatIdentifier` as the single source of format information.

This change also updates the builder API, tests, examples, and docs accordingly.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/identity-common`
- [x] Other: `@owf/eudi-attestation-schema`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)

## Testing

Ran package-scoped tests:

- `pnpm vitest run packages/eudi-attestation-schema/src/__tests__`

Result: 44 passed, 0 failed.

## Screenshots (if applicable)

N/A

## Additional Notes

Key files updated:

- `packages/eudi-attestation-schema/src/schemas.ts`
- `packages/eudi-attestation-schema/src/builders.ts`
- `packages/eudi-attestation-schema/src/__tests__/builders.test.mts`
- `packages/eudi-attestation-schema/src/__tests__/validator.test.mts`
- `packages/eudi-attestation-schema/src/__tests__/signer.test.mts`
- `packages/eudi-attestation-schema/src/__tests__/verifier.test.mts`
- `packages/eudi-attestation-schema/src/signer.ts`
- `packages/eudi-attestation-schema/examples/sign-and-verify.ts`
- `packages/eudi-attestation-schema/README.md`
- `.changeset/chilly-colts-nail.md`