### PR TITLE
fix(token-status-list): remove COSE re-exports and add ESM checks

### DIFF
--- a/.changeset/cold-readers-itch.md
+++ b/.changeset/cold-readers-itch.md
@@ -1,0 +1,6 @@
+---
+"@owf/token-status-list": minor
+"@owf/eudi-sca": minor
+---
+
+remove export from dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,7 +101,9 @@ jobs:
 
           pnpm changeset version --snapshot alpha
           pnpm style:fix
+          pnpm types:check
           pnpm build
+          pnpm esm:check
           pnpm changeset publish --tag alpha
 
           CURRENT_PACKAGE_VERSION=$(node -p "require('./packages/identity-common/package.json').version")

--- a/biome.json
+++ b/biome.json
@@ -26,6 +26,9 @@
     "enabled": true,
     "rules": {
       "recommended": true,
+      "style": {
+        "useImportType": "error"
+      },
       "correctness": {
         "recommended": true,
         "noUnusedImports": "error"

--- a/package.json
+++ b/package.json
@@ -16,11 +16,12 @@
     "md:check": "markdownlint-cli2 \"**/*.md\" \"#**/node_modules\"",
     "md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\"",
     "packages:check": "node scripts/check-package-entrypoints.mjs",
+    "esm:check": "node scripts/check-package-esm-imports.mjs",
     "build": "pnpm -r build",
     "pretest": "pnpm -r build",
     "test": "vitest",
     "create-package": "node scripts/create-package.mjs",
-    "release": "pnpm packages:check && pnpm build && pnpm changeset publish --no-git-tag 2>&1 | tee changeset-publish.log",
+    "release": "pnpm packages:check && pnpm types:check && pnpm build && pnpm esm:check && pnpm changeset publish --no-git-tag 2>&1 | tee changeset-publish.log",
     "changeset-version": "pnpm changeset version && pnpm style:fix",
     "prepare": "husky"
   },

--- a/packages/eudi-sca/src/index.ts
+++ b/packages/eudi-sca/src/index.ts
@@ -1,4 +1,5 @@
-export { base64url, Hasher } from '@owf/identity-common'
+export type { Hasher } from '@owf/identity-common'
+export { base64url } from '@owf/identity-common'
 export {
   type CredentialMetadata,
   type CredentialMetadataDisplay,

--- a/packages/token-status-list/src/cbor/status-list-cwt.ts
+++ b/packages/token-status-list/src/cbor/status-list-cwt.ts
@@ -1,7 +1,7 @@
+import type { Mac0Context } from '@owf/cose'
 import {
   type CoseKey,
   Cwt,
-  type Mac0Context,
   type ProtectedHeaderOptions,
   ProtectedHeaders,
   type Sign1Context,

--- a/packages/token-status-list/src/index.ts
+++ b/packages/token-status-list/src/index.ts
@@ -1,6 +1,3 @@
-// biome-ignore-all format: test file
-
-export {CoseKey, Mac0Context, MacAlgorithm, Sign1Context,SignatureAlgorithm } from '@owf/cose'
 export type { CreateStatusListCborOptions, StatusListCborWithStatusListOptions } from './cbor/status-list-cbor'
 export { StatusListCbor } from './cbor/status-list-cbor'
 export type { StatusListCwtOptions } from './cbor/status-list-cwt'

--- a/scripts/check-package-esm-imports.mjs
+++ b/scripts/check-package-esm-imports.mjs
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+
+import { readdir, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const rootDir = process.cwd()
+const packagesDir = join(rootDir, 'packages')
+const packageFilters = new Set(process.argv.slice(2))
+
+async function getWorkspacePackages() {
+  const entries = await readdir(packagesDir, { withFileTypes: true })
+  const packages = []
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue
+    }
+
+    const packageJsonPath = join(packagesDir, entry.name, 'package.json')
+    let packageJson
+
+    try {
+      packageJson = JSON.parse(await readFile(packageJsonPath, 'utf8'))
+    } catch (error) {
+      if (error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT') {
+        continue
+      }
+
+      throw error
+    }
+
+    if (
+      !packageJson.name ||
+      (packageFilters.size > 0 && !packageFilters.has(packageJson.name) && !packageFilters.has(entry.name))
+    ) {
+      continue
+    }
+
+    const esmEntry = packageJson.exports?.['.']?.import ?? packageJson.module
+    if (!esmEntry) {
+      continue
+    }
+
+    packages.push({
+      name: packageJson.name,
+      esmEntry: join(packagesDir, entry.name, esmEntry.replace(/^\.\//, '')),
+    })
+  }
+
+  return packages.sort((left, right) => left.name.localeCompare(right.name))
+}
+
+async function main() {
+  const packages = await getWorkspacePackages()
+  const failures = []
+
+  for (const { name, esmEntry } of packages) {
+    try {
+      await import(pathToFileURL(esmEntry).href)
+      console.log(`ESM import ok: ${name}`)
+    } catch (error) {
+      failures.push({ packageName: name, error })
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error('\nESM import validation failed:')
+    for (const { packageName, error } of failures) {
+      console.error(`\n${packageName}`)
+      console.error(error)
+    }
+    process.exit(1)
+  }
+
+  console.log(`\nESM import validation passed for ${packages.length} package(s).`)
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "sourceMap": true,
     "strict": true,
+    "isolatedModules": true,
     "skipLibCheck": true,
     "noEmitOnError": true,
     "lib": ["ES2020", "DOM.Iterable", "DOM"],


### PR DESCRIPTION
## Description

Removes the `@owf/cose` convenience re-exports from `@owf/token-status-list` so COSE runtime/type-only symbols are imported from their owning package directly. This avoids ESM runtime export validation failures caused by pass-through barrels re-exporting type-only symbols as runtime exports.

Also adds guardrails to catch this class of issue earlier:

- enables Biome `useImportType`
- enables TypeScript `isolatedModules`
- adds a built-package ESM import smoke check
- runs type checking and ESM validation before release publish
- fixes a related type-only re-export in `@owf/eudi-sca`

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/identity-common`
- [x] Other: `@owf/token-status-list`, `@owf/eudi-sca`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [ ] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)

## Testing

- `pnpm style:check`
- `pnpm types:check`
- `pnpm -r build`
- `pnpm esm:check`
- `pnpm vitest packages/token-status-list/src/__tests__ --run` — 121 tests passed

## Screenshots (if applicable)

N/A

## Additional Notes

This intentionally removes the COSE pass-through exports from `@owf/token-status-list`. Consumers should import `CoseKey`, `MacAlgorithm`, `SignatureAlgorithm`, `Mac0Context`, and `Sign1Context` directly from `@owf/cose`.