### PR TITLE
feat: add Turborepo for build and test caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,31 @@ jobs:
 
       - uses: pnpm/action-setup@v6
       - name: Setup NodeJS
+        id: setup-node
         uses: actions/setup-node@v6
         with:
           node-version: 24
-          cache: "pnpm"
+
+      # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
+      - name: pnpm cache path
+        id: pnpm-cache-path
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: pnpm cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.pnpm-cache-path.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Turbo cache
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-validate-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-validate-
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -36,10 +57,11 @@ jobs:
         run: pnpm md:check
 
       - name: Check Types
+        # pretypes:check runs `turbo run build` automatically; no separate build step needed
         run: pnpm types:check
-
-      - name: Compile
-        run: pnpm build
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}
 
   tests:
     runs-on: ubuntu-24.04
@@ -65,8 +87,7 @@ jobs:
       # See https://github.com/actions/setup-node/issues/641#issuecomment-1358859686
       - name: pnpm cache path
         id: pnpm-cache-path
-        run: |
-          echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: pnpm cache
         uses: actions/cache@v5
@@ -76,8 +97,19 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-pnpm-store-
 
+      - name: Turbo cache
+        uses: actions/cache@v5
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-turbo-test-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-${{ steps.setup-node.outputs.node-version }}-turbo-test-
+
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Run tests
         run: pnpm test
+        env:
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TEAM: ${{ secrets.TURBO_TEAM }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 node_modules
 dist
 .tgz
+.turbo

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ yarn add @owf/identity-common
 
 ### Development Setup
 
-To contribute or develop locally:
+This monorepo uses [pnpm](https://pnpm.io) for package management and [Turborepo](https://turbo.build/repo) for task orchestration.
 
 ```bash
 # Clone the repository
@@ -177,9 +177,46 @@ pnpm install
 # Build all packages
 pnpm build
 
-# Run tests
+# Run all tests
 pnpm test
 ```
+
+### Turborepo
+
+All build and test tasks run through **Turborepo**, which provides:
+
+- **Caching** — tasks whose inputs haven't changed are skipped entirely (a cached full run completes in ~15ms)
+- **Parallelism** — independent packages build and test concurrently
+- **Correct ordering** — packages are always built before the packages that depend on them
+
+#### Task pipeline
+
+| Task | Depends on | What it does |
+|------|-----------|--------------|
+| `build` | upstream `build` | Compiles each package with `tsdown` (ESM + CJS + `.d.ts`) |
+| `test` | upstream `build` | Runs `vitest` tests for each package |
+| `types:check` | upstream `build` | Type-checks the workspace with `tsc --noEmit` |
+| `esm:check` | local `build` | Validates ESM import paths |
+| `lint` | — | Linting (no build prerequisite) |
+
+Run any task across all packages:
+
+```bash
+pnpm build          # turbo run build
+pnpm test           # turbo run test
+
+# Scope to a single package
+npx turbo run build --filter=@owf/identity-common
+npx turbo run test  --filter=@owf/crypto
+```
+
+The first run executes everything. Subsequent runs that find no changed inputs print `FULL TURBO` and finish instantly.
+
+#### Cache details
+
+Turbo computes a hash for each task from its **input files** (`src/**`, `package.json`, `tsconfig.json`), the global config (`tsconfig.json`, `vite.config.js`), and the pnpm lockfile. If the hash matches a previously-stored result the task is restored from `.turbo/cache/` without re-running.
+
+The `.turbo/` directory is intentionally **not committed** (`.gitignore`) — every developer gets their own local cache.
 
 ---
 
@@ -242,7 +279,14 @@ Please read our [Contributing Guide](./CONTRIBUTING.md) to get started.
 
 ### Adding a New Package
 
-Want to add a new package to the monorepo? Check out our [guide for adding packages](./CONTRIBUTING.md#adding-a-new-package).
+A script is provided to scaffold a new package with the correct structure, build config, and Turborepo wiring already in place:
+
+```bash
+pnpm create-package <name>           # e.g. jose
+pnpm create-package <name> --eudi   # prefixes with eudi-
+```
+
+See the [guide for adding packages](./CONTRIBUTING.md#adding-a-new-package) for details.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "license": "Apache-2.0",
   "scripts": {
-    "pretypes:check": "pnpm -r build",
+    "pretypes:check": "turbo run build",
     "types:check": "tsc --noEmit",
     "style:check": "biome check --unsafe",
     "style:fix": "biome check --write --unsafe",
@@ -17,9 +17,8 @@
     "md:fix": "markdownlint-cli2 --fix \"**/*.md\" \"#**/node_modules\"",
     "packages:check": "node scripts/check-package-entrypoints.mjs",
     "esm:check": "node scripts/check-package-esm-imports.mjs",
-    "build": "pnpm -r build",
-    "pretest": "pnpm -r build",
-    "test": "vitest",
+    "build": "turbo run build",
+    "test": "turbo run test",
     "create-package": "node scripts/create-package.mjs",
     "release": "pnpm packages:check && pnpm types:check && pnpm build && pnpm esm:check && pnpm changeset publish --no-git-tag 2>&1 | tee changeset-publish.log",
     "changeset-version": "pnpm changeset version && pnpm style:fix",
@@ -36,9 +35,10 @@
     "lint-staged": "^16.4.0",
     "markdownlint-cli2": "^0.22.0",
     "tsdown": "0.21.9",
+    "tsx": "^4.21.0",
+    "turbo": "^2.9.14",
     "typescript": "catalog:",
-    "vitest": "^4.1.4",
-    "tsx": "^4.21.0"
+    "vitest": "^4.1.4"
   },
   "engines": {
     "node": ">=20"

--- a/packages/cose/package.json
+++ b/packages/cose/package.json
@@ -39,7 +39,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@owf/identity-common": "workspace:*",
@@ -52,6 +53,7 @@
     "@noble/hashes": "^2.0.1",
     "@panva/hkdf": "^1.2.1",
     "@peculiar/x509": "^1.14.3",
-    "jose": "^6.1.0"
+    "jose": "^6.1.0",
+    "vitest": "catalog:"
   }
 }

--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -39,10 +39,14 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@noble/hashes": "^2.2.0",
     "@owf/identity-common": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/packages/eudi-attestation-schema/package.json
+++ b/packages/eudi-attestation-schema/package.json
@@ -51,11 +51,15 @@
     "ts11"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",
     "@owf/identity-common": "workspace:*",
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/packages/eudi-lote/package.json
+++ b/packages/eudi-lote/package.json
@@ -50,11 +50,15 @@
     "jwt"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",
     "@owf/identity-common": "workspace:*",
     "zod": "catalog:"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/packages/eudi-sca/package.json
+++ b/packages/eudi-sca/package.json
@@ -46,7 +46,8 @@
     "wallet"
   ],
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@openid4vc/openid4vci": "0.5.0-alpha-20260415063740",
@@ -59,6 +60,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "nock": "^14.0.13"
+    "nock": "^14.0.13",
+    "vitest": "catalog:"
   }
 }

--- a/packages/eudi-wrprc/package.json
+++ b/packages/eudi-wrprc/package.json
@@ -50,12 +50,15 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@owf/crypto": "workspace:*",
     "@owf/identity-common": "workspace:*",
     "zod": "catalog:"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "vitest": "catalog:"
+  }
 }

--- a/packages/identity-common/package.json
+++ b/packages/identity-common/package.json
@@ -39,6 +39,10 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "vitest": "catalog:"
   }
 }

--- a/packages/token-status-list/package.json
+++ b/packages/token-status-list/package.json
@@ -39,7 +39,8 @@
     }
   },
   "scripts": {
-    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap"
+    "build": "tsdown src/index.ts --format esm,cjs --dts --sourcemap",
+    "test": "vitest run"
   },
   "dependencies": {
     "@owf/cose": "workspace:*",
@@ -49,6 +50,7 @@
     "zod": "catalog:"
   },
   "devDependencies": {
-    "@types/pako": "^2.0.4"
+    "@types/pako": "^2.0.4",
+    "vitest": "catalog:"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,9 @@ catalogs:
     typescript:
       specifier: ~6.0.2
       version: 6.0.3
+    vitest:
+      specifier: ^4.1.4
+      version: 4.1.5
     zod:
       specifier: ^4.4.3
       version: 4.4.3
@@ -50,6 +53,9 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
+      turbo:
+        specifier: ^2.9.14
+        version: 2.9.14
       typescript:
         specifier: 'catalog:'
         version: 6.0.3
@@ -87,6 +93,9 @@ importers:
       jose:
         specifier: ^6.1.0
         version: 6.2.3
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/crypto:
     dependencies:
@@ -96,6 +105,10 @@ importers:
       '@owf/identity-common':
         specifier: workspace:*
         version: link:../identity-common
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eudi-attestation-schema:
     dependencies:
@@ -108,6 +121,10 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eudi-lote:
     dependencies:
@@ -120,6 +137,10 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eudi-sca:
     dependencies:
@@ -151,6 +172,9 @@ importers:
       nock:
         specifier: ^14.0.13
         version: 14.0.13
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/eudi-wrprc:
     dependencies:
@@ -163,8 +187,16 @@ importers:
       zod:
         specifier: 'catalog:'
         version: 4.4.3
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
-  packages/identity-common: {}
+  packages/identity-common:
+    devDependencies:
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
   packages/token-status-list:
     dependencies:
@@ -187,6 +219,9 @@ importers:
       '@types/pako':
         specifier: ^2.0.4
         version: 2.0.4
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.5(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.7)(tsx@4.21.0)(yaml@2.8.3))
 
 packages:
 
@@ -868,6 +903,36 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@turbo/darwin-64@2.9.14':
+    resolution: {integrity: sha512-t7QiPflaEyBE4oayeZtSmu4mEfjgIrcNlNNl1z1dmIVPqEdtA7+CfTf8d7KXsOGPh6aNgWjKxyvQg9uGfDQF+A==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.14':
+    resolution: {integrity: sha512-d23147mC9BsCPA9mJ0h/ubcpbRgcJBXbcG3+Vq7YLhjz3IXuvQsJ1UXH8f4MD76ZjJ4m/E4aRdJV+MW88CDfbw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.14':
+    resolution: {integrity: sha512-P3ZKB5tuUDdDQWuAsACGUR1qv9W7BNWxdxqVJ0kZNuNNPRaVYTPPikLcp79+GiEcW3npsR+KyP38lnQiBc5aSA==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.14':
+    resolution: {integrity: sha512-ZRTlzcUMrrPv9ZuDzRF9n60Ym13bKeG9jDB8WjxyLhWNzV+AJQN+zdpIk3NJYf2zQsGUm1mNar2P0elRzLw25g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.14':
+    resolution: {integrity: sha512-exanwN6sIduZwykYeiTQj8kCmOhazP5WOz3bvXMcYtjhL6Z3iRWLewKrXCBq0bqwSP3iBMb/AerRCnHI4lx46A==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.14':
+    resolution: {integrity: sha512-fVdCsnmYoKICsycbWuuGp6Jvi51/3G/UluFWuAUCvR8PIW5IJkAk5BM9UF8PSm0Q2IphWHFZjYEgjHsh3B9y/g==}
+    cpu: [arm64]
+    os: [win32]
 
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
@@ -1856,6 +1921,10 @@ packages:
     resolution: {integrity: sha512-axr3IdNuVIxnaK5XGEUFTu3YmAQ6lllgrvqfEoR16g/HGnYY/6We4oWENtAnzK6/LpJ2ur9PAb80RBt7/U4ugw==}
     engines: {node: '>= 6.0.0'}
 
+  turbo@2.9.14:
+    resolution: {integrity: sha512-BQqXRr4UoWI3UPFrtznCLykYHxwxWh53iCB57x092jPMjIlW1wnm3N895g5irpiXmnxUhREBB0n6+y8BHhs4nw==}
+    hasBin: true
+
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
@@ -2684,6 +2753,24 @@ snapshots:
   '@sindresorhus/merge-streams@4.0.0': {}
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@turbo/darwin-64@2.9.14':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.14':
+    optional: true
+
+  '@turbo/linux-64@2.9.14':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.14':
+    optional: true
+
+  '@turbo/windows-64@2.9.14':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.14':
+    optional: true
 
   '@tybys/wasm-util@0.10.1':
     dependencies:
@@ -3729,6 +3816,15 @@ snapshots:
   tsyringe@4.10.0:
     dependencies:
       tslib: 1.14.1
+
+  turbo@2.9.14:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.14
+      '@turbo/darwin-arm64': 2.9.14
+      '@turbo/linux-64': 2.9.14
+      '@turbo/linux-arm64': 2.9.14
+      '@turbo/windows-64': 2.9.14
+      '@turbo/windows-arm64': 2.9.14
 
   typescript@6.0.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,4 @@ packages:
 catalog:
   zod: ^4.4.3
   typescript: ~6.0.2
+  vitest: ^4.1.4

--- a/scripts/create-package.mjs
+++ b/scripts/create-package.mjs
@@ -83,9 +83,12 @@ const packageJson = {
   },
   scripts: {
     build: 'tsdown src/index.ts --format esm,cjs --dts --sourcemap',
+    test: 'vitest run',
   },
   dependencies: {},
-  devDependencies: {},
+  devDependencies: {
+    vitest: 'catalog:',
+  },
 }
 
 // tsconfig.json template
@@ -189,8 +192,8 @@ async function main() {
     console.log(`  2. Add your code to packages/${packageName}/src/index.ts`)
     console.log(`  3. Add tests to packages/${packageName}/src/__tests__/`)
     console.log('  4. Run: pnpm install')
-    console.log('  5. Run: pnpm build')
-    console.log('  6. Run: pnpm test')
+    console.log('  5. Run: pnpm build  (or: turbo run build)')
+    console.log('  6. Run: pnpm test   (or: turbo run test)')
     console.log('')
   } catch (error) {
     console.error('Error creating package:', error)

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["tsconfig.json", "vite.config.js"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "package.json", "tsconfig.json"],
+      "outputs": ["dist/**"]
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["src/**", "package.json"],
+      "outputs": []
+    },
+    "types:check": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "esm:check": {
+      "dependsOn": ["build"],
+      "outputs": []
+    },
+    "lint": {
+      "inputs": ["src/**", "package.json"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Wires [Turborepo](https://turbo.build/repo) into the pnpm monorepo to enable local task caching and correct build ordering.

After the fix, a second `turbo run build` or `turbo run test` with no changes completes in ~15ms (**FULL TURBO**).

## Changes

### Infrastructure
- **`turbo.json`** — Defines the task pipeline:
  - `build` depends on upstream `^build` (packages build in dependency order); inputs: `src/**`, `package.json`, `tsconfig.json`; outputs: `dist/**`
  - `test` depends on upstream `^build`; no outputs (always re-runs on input change)
  - `types:check`, `esm:check`, `lint` wired in with correct `dependsOn`
  - `globalDependencies: ["tsconfig.json", "vite.config.js"]` so root config changes invalidate all tasks
- **`.gitignore`** — Added `.turbo` (critical: without this, turbo's log files were untracked, causing the global hash to change every run and preventing any cache hits)
- **`pnpm-workspace.yaml`** — Added `vitest: ^4.1.4` to the shared catalog
- **`package.json`** (root) — `build` and `test` scripts now delegate to `turbo run build` / `turbo run test`

### All 8 packages
Each `packages/*/package.json` received:
- `"test": "vitest run"` script (required for `turbo run test` to work per-package)
- `"vitest": "catalog:"` in `devDependencies`

### Tooling
- **`scripts/create-package.mjs`** — Updated template so newly generated packages include the `test` script and `vitest` devDependency out of the box

### Documentation
- **`README.md`** — Added a full **Turborepo** section explaining the task pipeline, caching behaviour, available commands, and how to run tasks for a single package

## Cache behaviour

| Run | Result |
|-----|--------|
| First `pnpm build` | All 8 packages built |
| Second `pnpm build` (no changes) | `Cached: 8 cached, 8 total, Time: ~15ms` |
| First `pnpm test` | All 11 test tasks run |
| Second `pnpm test` (no changes) | `Cached: 11 cached, 11 total, Time: ~16ms >>> FULL TURBO` |
