### PR TITLE
refactor: only allow CoseKey as return value for PublicKey in x509 context

### DIFF
--- a/.changeset/cyan-parts-open.md
+++ b/.changeset/cyan-parts-open.md
@@ -1,0 +1,6 @@
+---
+"@owf/token-status-list": minor
+"@owf/cose": minor
+---
+
+refactor: only allow CoseKey as return value for getPublicKey in x509 context

--- a/.changeset/eleven-clubs-sink.md
+++ b/.changeset/eleven-clubs-sink.md
@@ -1,0 +1,6 @@
+---
+"@owf/token-status-list": minor
+"@owf/cose": minor
+---
+
+refactor: only allow CosKey for sign1.verify

--- a/packages/cose/src/__tests__/context.ts
+++ b/packages/cose/src/__tests__/context.ts
@@ -1,11 +1,20 @@
-import type { Mac0Context, Sign1Context } from '../cose'
+import { CoseKey, type Mac0Context, type Sign1Context } from '../cose'
 
 export const sign1Context: Sign1Context = {
   sign: async () => new Uint8Array([1, 2, 3]),
   verify: async () => true,
   x509: {
     getIssuerNameField: () => ['a', 'v'],
-    getPublicKey: async () => new Uint8Array([7, 8, 9]),
+    getPublicKey: async () =>
+      CoseKey.fromJwk({
+        kty: 'EC',
+        d: 'hGc90b8KMIjIpZos81yEFbOMc0Ww3k5ZNWICzDwtFV4',
+        use: 'sig',
+        crv: 'P-256',
+        x: 'eBUFGSPkdYwJ9TqYpcNxhAyr-A8wlWzrLQJppSi3x0E',
+        y: 'Jnf8v4steg6Gr4IEFpg_xcM5xdHKdngbQN9ERJbJvl8',
+        alg: 'ES256',
+      }),
   },
 }
 

--- a/packages/cose/src/cose/sign1.ts
+++ b/packages/cose/src/cose/sign1.ts
@@ -48,7 +48,7 @@ export type Sign1Context = {
   verify: (options: { sign1: Sign1; key: Uint8Array | CoseKey }) => Promise<boolean>
   x509: {
     getIssuerNameField: (options: { certificate: Uint8Array; field: string }) => string[]
-    getPublicKey: (options: { certificate: Uint8Array; alg: string }) => Promise<Uint8Array>
+    getPublicKey: (options: { certificate: Uint8Array; alg: string }) => Promise<CoseKey>
   }
 }
 

--- a/packages/cose/src/cose/sign1.ts
+++ b/packages/cose/src/cose/sign1.ts
@@ -45,7 +45,7 @@ export type Sign1DecodedStructure = z.infer<typeof sign1DecodedSchema>
 
 export type Sign1Context = {
   sign: (options: { toBeSigned: Uint8Array; key: CoseKey; algorithm: SignatureAlgorithm }) => Promise<Uint8Array>
-  verify: (options: { sign1: Sign1; key: Uint8Array | CoseKey }) => Promise<boolean>
+  verify: (options: { sign1: Sign1; key: CoseKey }) => Promise<boolean>
   x509: {
     getIssuerNameField: (options: { certificate: Uint8Array; field: string }) => string[]
     getPublicKey: (options: { certificate: Uint8Array; alg: string }) => Promise<CoseKey>

--- a/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.mts
+++ b/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.mts
@@ -11,7 +11,16 @@ const sign1Context: Sign1Context = {
   verify: async () => true,
   x509: {
     getIssuerNameField: () => ['a', 'v'],
-    getPublicKey: async () => new Uint8Array([7, 8, 9]),
+    getPublicKey: async () =>
+      CoseKey.fromJwk({
+        kty: 'EC',
+        d: 'hGc90b8KMIjIpZos81yEFbOMc0Ww3k5ZNWICzDwtFV4',
+        use: 'sig',
+        crv: 'P-256',
+        x: 'eBUFGSPkdYwJ9TqYpcNxhAyr-A8wlWzrLQJppSi3x0E',
+        y: 'Jnf8v4steg6Gr4IEFpg_xcM5xdHKdngbQN9ERJbJvl8',
+        alg: 'ES256',
+      }),
   },
 }
 


### PR DESCRIPTION
This changes the type, i'm not so sure why we allow Uint8Array only, while in Mdoc it's either CoseKey or Uint8Array? I think we should just allow CoseKey.