### PR TITLE
refactor: algorithm handling for COSE

### DIFF
--- a/.changeset/dirty-clocks-start.md
+++ b/.changeset/dirty-clocks-start.md
@@ -1,0 +1,5 @@
+---
+"@owf/cose": minor
+---
+
+asdf

--- a/.changeset/dirty-clocks-start.md
+++ b/.changeset/dirty-clocks-start.md
@@ -2,4 +2,10 @@
 "@owf/cose": minor
 ---
 
-asdf
+Reworked the handling of algorithm name extraction:
+
+- `alg` is only extracted from protected headers for Mac0 and Sign1
+- No error is thrown when the alg cannot be extracted, since it's not a required parameter according to the COSE spec
+- `algorithmName` on the Mac0 and Sign1 classes have been replaced by `algorithm` (COSE Algorithm identifier, number) and `jwaAlgorithm` (JOSE Algorithm identifier, string)
+- `algorithm` is now provided to the verification methods in Sign1 and Mac0 context as optional parameter
+- The `alg` parameter in `x509.getPublicKey` context method has been renamed to `algorithm` is now a COSE algorithm identifier, and optional due to `alg` not being required in Mac0 and Sign1 anymore.

--- a/packages/cose/src/cose/mac0.ts
+++ b/packages/cose/src/cose/mac0.ts
@@ -43,7 +43,12 @@ export type Mac0DecodedStructure = z.infer<typeof mac0DecodedSchema>
 
 export type Mac0Context = {
   authenticate: (options: { toBeAuthenticated: Uint8Array; key: CoseKey | Uint8Array }) => Promise<Uint8Array>
-  verify: (options: { toBeAuthenticated: Uint8Array; tag: Uint8Array; key: CoseKey | Uint8Array }) => Promise<boolean>
+  verify: (options: {
+    toBeAuthenticated: Uint8Array
+    tag: Uint8Array
+    key: CoseKey | Uint8Array
+    algorithm?: MacAlgorithm
+  }) => Promise<boolean>
 }
 
 export type Mac0Options = {
@@ -165,21 +170,21 @@ export class Mac0 extends CborStructure<Mac0EncodedStructure, Mac0DecodedStructu
     return cborEncode(toBeAuthenticated)
   }
 
-  public get signatureAlgorithmName(): MacAlgorithm {
-    const algorithm = (this.protectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm) ??
-      this.unprotectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm)) as MacAlgorithm | undefined
+  public get algorithm(): MacAlgorithm | undefined {
+    const algorithm = this.protectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm)
 
-    if (!algorithm) {
-      throw new CoseInvalidAlgorithmError()
+    return algorithm as MacAlgorithm | undefined
+  }
+
+  public get jwaAlgorithm(): keyof typeof MacAlgorithm {
+    const alg = this.algorithm
+
+    const jwaAlg = coseKeyToJwkClaim.algorithm(alg)
+    if (!jwaAlg) {
+      throw new CoseInvalidAlgorithmError(`Cose algorithm ${alg} does not have a corresponding JWA alg`)
     }
 
-    const algorithmName = coseKeyToJwkClaim.algorithm(algorithm)
-
-    if (!algorithmName) {
-      throw new CoseInvalidAlgorithmError()
-    }
-
-    return algorithmName
+    return jwaAlg
   }
 
   public static create(options: Mac0Options): Mac0 {

--- a/packages/cose/src/cose/sign1.ts
+++ b/packages/cose/src/cose/sign1.ts
@@ -45,10 +45,15 @@ export type Sign1DecodedStructure = z.infer<typeof sign1DecodedSchema>
 
 export type Sign1Context = {
   sign: (options: { toBeSigned: Uint8Array; key: CoseKey; algorithm: SignatureAlgorithm }) => Promise<Uint8Array>
-  verify: (options: { toBeVerified: Uint8Array; signature: Uint8Array; key: CoseKey }) => Promise<boolean>
+  verify: (options: {
+    toBeVerified: Uint8Array
+    signature: Uint8Array
+    key: CoseKey
+    algorithm?: SignatureAlgorithm
+  }) => Promise<boolean>
   x509: {
     getIssuerNameField: (options: { certificate: Uint8Array; field: string }) => string[]
-    getPublicKey: (options: { certificate: Uint8Array; alg: string }) => Promise<CoseKey>
+    getPublicKey: (options: { certificate: Uint8Array; algorithm?: SignatureAlgorithm }) => Promise<CoseKey>
   }
 }
 
@@ -204,21 +209,22 @@ export class Sign1 extends CborStructure<Sign1EncodedStructure, Sign1DecodedStru
     return cborEncode(toBeSigned)
   }
 
-  public get signatureAlgorithmName(): string {
-    // FIXME: why are we looking at the unprotected header for the alg?
-    const algorithm = (this.protectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm) ??
-      this.unprotectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm)) as SignatureAlgorithm | undefined
+  public get algorithm(): SignatureAlgorithm | undefined {
+    const algorithm = this.protectedHeaders.headers?.get(RegisteredCwtHeaderClaimKey.Algorithm)
 
-    if (!algorithm) {
-      throw new CoseInvalidAlgorithmError()
+    return algorithm as SignatureAlgorithm | undefined
+  }
+
+  public get jwaAlgorithm(): keyof typeof SignatureAlgorithm | undefined {
+    const alg = this.algorithm
+    if (!alg) return undefined
+
+    const jwaAlg = coseKeyToJwkClaim.algorithm(alg)
+    if (!jwaAlg) {
+      throw new CoseInvalidAlgorithmError(`Cose algorithm ${alg} does not have a corresponding JWA alg`)
     }
 
-    const algorithmName = coseKeyToJwkClaim.algorithm(algorithm)
-    if (!algorithmName) {
-      throw new CoseInvalidAlgorithmError()
-    }
-
-    return algorithmName
+    return jwaAlg
   }
 
   public get x5chain() {
@@ -257,7 +263,7 @@ export class Sign1 extends CborStructure<Sign1EncodedStructure, Sign1DecodedStru
       (this.certificate
         ? await ctx.x509.getPublicKey({
             certificate: this.certificate,
-            alg: this.signatureAlgorithmName,
+            algorithm: this.algorithm,
           })
         : undefined)
 
@@ -269,6 +275,7 @@ export class Sign1 extends CborStructure<Sign1EncodedStructure, Sign1DecodedStru
       toBeVerified: this.toBeSigned({ detachedPayload }),
       signature: this.signature,
       key: publicKey,
+      algorithm: this.algorithm,
     })
   }
 


### PR DESCRIPTION
We were missing the alg now that we didn't provide the class instance  anymore. I added the alg and reworked it a bit as I'm not sure why we were extracting from the unprotected header (this is only true for X5c chain in mdocs), and i think we should stick to COSE algorithms in the COSE library and let the user handle the conversion.