### PR TITLE
chore: fix ttl and exp claims when not defined

### DIFF
--- a/packages/token-status-list/src/__tests__/cbor/status-list-cwt-payload.test.ts
+++ b/packages/token-status-list/src/__tests__/cbor/status-list-cwt-payload.test.ts
@@ -23,6 +23,33 @@ suite('StatusListCwtPayload', () => {
     const fromEncoded = StatusListCwtPayload.decode(encoded)
 
     expect(fromEncoded).toMatchObject(payload)
+    expect(fromEncoded.timeToLive).toBeUndefined()
+    expect(fromEncoded.expirationTime).toBeUndefined()
+  })
+
+  test('encode/decode with exp and ttl', () => {
+    const statusList = new StatusList(new Array(10).fill(0), 4, 'https://example.com/aggregate')
+    statusList.setStatus(0, 1)
+    statusList.setStatus(5, 1)
+
+    const cborStatusList = StatusListCbor.create({
+      statusList,
+    })
+
+    const payload = StatusListCwtPayload.create({
+      subject: 'https://example.com/statuslists/1',
+      issuedAt: new Date(1000000 * 1000),
+      statusList: cborStatusList,
+      expirationTime: new Date(1001000 * 1000),
+      timeToLive: 5,
+    })
+
+    const encoded = payload.encode()
+    const fromEncoded = StatusListCwtPayload.decode(encoded)
+
+    expect(fromEncoded).toMatchObject(payload)
+    expect(fromEncoded.timeToLive).toBeDefined()
+    expect(fromEncoded.expirationTime).toBeDefined()
   })
 
   test('encode/decode with additional claims', () => {

--- a/packages/token-status-list/src/cbor/status-list-cwt-payload.ts
+++ b/packages/token-status-list/src/cbor/status-list-cwt-payload.ts
@@ -12,8 +12,8 @@ const statusListCwtPayloadSchema = typedMap(
   [
     [RegisteredCwtClaimKey.Subject, z.string()],
     [RegisteredCwtClaimKey.IssuedAt, z.number()],
-    [RegisteredCwtClaimKey.ExpirationTime, z.number().optional()],
-    [StatusListCwtClaimKey.TimeToLive, z.number().optional()],
+    [RegisteredCwtClaimKey.ExpirationTime, z.number().exactOptional()],
+    [StatusListCwtClaimKey.TimeToLive, z.number().exactOptional()],
     [StatusListCwtClaimKey.StatusList, z.instanceof(StatusListCbor)],
   ],
   { allowAdditionalKeys: true }
@@ -62,11 +62,6 @@ export class StatusListCwtPayload extends CborStructure<
       [RegisteredCwtClaimKey.Subject, options.subject],
       [RegisteredCwtClaimKey.IssuedAt, Math.floor((options.issuedAt?.getTime() ?? Date.now()) / 1000)],
       [
-        RegisteredCwtClaimKey.ExpirationTime,
-        options.expirationTime ? Math.floor(options.expirationTime.getTime() / 1000) : undefined,
-      ],
-      [StatusListCwtClaimKey.TimeToLive, options.timeToLive],
-      [
         StatusListCwtClaimKey.StatusList,
         options.statusList instanceof StatusListCbor
           ? options.statusList
@@ -74,6 +69,14 @@ export class StatusListCwtPayload extends CborStructure<
       ],
       ...(options.additionalClaims ?? new Map()).entries(),
     ]) satisfies StatusListCwtPayloadEncodedStructure
+
+    if (options.expirationTime) {
+      map.set(RegisteredCwtClaimKey.ExpirationTime, Math.floor(options.expirationTime.getTime() / 1000))
+    }
+
+    if (options.timeToLive) {
+      map.set(StatusListCwtClaimKey.TimeToLive, options.timeToLive)
+    }
 
     return new StatusListCwtPayload(statusListCwtPayloadSchema.parse(map.toMap()))
   }


### PR DESCRIPTION
Make sure the exp and ttl are only set when they are defined
