### PR TITLE
feat(cose): type known header claims; validate kid as bstr at decode

### DIFF
--- a/.changeset/typed-cose-header-claims.md
+++ b/.changeset/typed-cose-header-claims.md
@@ -1,0 +1,5 @@
+---
+"@owf/cose": minor
+---
+
+Type the known COSE header claims. `kid` (label 4) is now validated as a bstr when decoding protected and unprotected headers, so a malformed `{ 4: undefined }` is rejected for every `Sign1`-derived structure (e.g. a `deviceSignature`) instead of being silently accepted. The other registered labels are enumerated as known keys; additional/private-use labels still pass through. `ProtectedHeaders`/`UnprotectedHeaders` now back their structure with a `TypedMap`, and the `.headers` accessor keeps `kid` typed as a bstr while allowing access to any other integer label.

--- a/packages/cose/src/__tests__/cwt.test.ts
+++ b/packages/cose/src/__tests__/cwt.test.ts
@@ -34,9 +34,9 @@ describe('Cwt', () => {
       const payload = hex.decode('a10150636f61703a2f2f61732e6578616d706c65') // {"1":"coap://as.example"}
 
       const sign1 = Sign1.create({
-        protectedHeaders: ProtectedHeaders.fromDecodedStructure(
-          new Map([[RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256]])
-        ),
+        protectedHeaders: ProtectedHeaders.create({
+          protectedHeaders: new Map([[RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256]]),
+        }),
         unprotectedHeaders: new Map(),
         payload,
       })
@@ -55,9 +55,9 @@ describe('Cwt', () => {
       const payload = hex.decode('a10150636f61703a2f2f61732e6578616d706c65')
 
       const sign1 = Sign1.create({
-        protectedHeaders: ProtectedHeaders.fromDecodedStructure(
-          new Map([[RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256]])
-        ),
+        protectedHeaders: ProtectedHeaders.create({
+          protectedHeaders: new Map([[RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256]]),
+        }),
         unprotectedHeaders: new Map(),
         payload,
       })
@@ -95,9 +95,9 @@ describe('Cwt', () => {
       const payload = hex.decode('a10150636f61703a2f2f61732e6578616d706c65')
 
       const mac0 = Mac0.create({
-        protectedHeaders: ProtectedHeaders.fromDecodedStructure(
-          new Map([[RegisteredCwtHeaderClaimKey.Algorithm, MacAlgorithm.HS256]])
-        ),
+        protectedHeaders: ProtectedHeaders.create({
+          protectedHeaders: new Map([[RegisteredCwtHeaderClaimKey.Algorithm, MacAlgorithm.HS256]]),
+        }),
         unprotectedHeaders: new Map(),
         payload,
       })
@@ -116,9 +116,9 @@ describe('Cwt', () => {
       const payload = hex.decode('a10150636f61703a2f2f61732e6578616d706c65')
 
       const mac0 = Mac0.create({
-        protectedHeaders: ProtectedHeaders.fromDecodedStructure(
-          new Map([[RegisteredCwtHeaderClaimKey.Algorithm, MacAlgorithm.HS256]])
-        ),
+        protectedHeaders: ProtectedHeaders.create({
+          protectedHeaders: new Map([[RegisteredCwtHeaderClaimKey.Algorithm, MacAlgorithm.HS256]]),
+        }),
         unprotectedHeaders: new Map(),
         payload,
       })

--- a/packages/cose/src/__tests__/header-claims.test.ts
+++ b/packages/cose/src/__tests__/header-claims.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from 'vitest'
+import { cborEncode } from '../cbor'
+import { RegisteredCwtHeaderClaimKey } from '../cose/headers/defaults'
+import { ProtectedHeaders } from '../cose/headers/protected-headers'
+import { UnprotectedHeaders } from '../cose/headers/unprotected-headers'
+
+const { KeyId, X5Chain } = RegisteredCwtHeaderClaimKey
+
+describe('cose header claims', () => {
+  test('a bstr kid is accepted and typed', () => {
+    const kid = new Uint8Array([1, 2, 3])
+    const headers = UnprotectedHeaders.create({ unprotectedHeaders: new Map([[KeyId, kid]]) })
+    expect(headers.headers.get(KeyId)).toStrictEqual(kid)
+  })
+
+  test('a malformed kid ({ 4: undefined }) is rejected when decoding unprotected headers', () => {
+    const bytes = cborEncode(new Map<number, unknown>([[KeyId, undefined]]))
+    expect(() => UnprotectedHeaders.decode(bytes)).toThrow()
+  })
+
+  test('a malformed kid is rejected when decoding protected headers', () => {
+    const innerMap = cborEncode(new Map<number, unknown>([[KeyId, undefined]]))
+    expect(() => ProtectedHeaders.fromEncodedStructure(innerMap)).toThrow()
+  })
+
+  test('a non-bstr kid is rejected', () => {
+    const bytes = cborEncode(new Map<number, unknown>([[KeyId, 'not-bytes']]))
+    expect(() => UnprotectedHeaders.decode(bytes)).toThrow()
+  })
+
+  test('other header labels (e.g. x5chain) pass through untouched', () => {
+    const chain = [new Uint8Array([9])]
+    const headers = UnprotectedHeaders.create({ unprotectedHeaders: new Map([[X5Chain, chain]]) })
+    expect(headers.headers.get(X5Chain)).toStrictEqual(chain)
+    // No kid present is fine.
+    expect(headers.headers.get(KeyId)).toBeUndefined()
+  })
+})

--- a/packages/cose/src/__tests__/sign1.test.ts
+++ b/packages/cose/src/__tests__/sign1.test.ts
@@ -33,9 +33,11 @@ describe('sign1', () => {
       const key = CoseKey.fromJwk(testVector.key)
 
       const sign1 = Sign1.fromDecodedStructure({
-        protectedHeaders: ProtectedHeaders.fromDecodedStructure(
-          cborDecode(hex.decode(testVector['sign1::sign'].protectedHeaders.cborHex))
-        ),
+        protectedHeaders: ProtectedHeaders.create({
+          protectedHeaders: cborDecode<Map<number, unknown>>(
+            hex.decode(testVector['sign1::sign'].protectedHeaders.cborHex)
+          ),
+        }),
         unprotectedHeaders: UnprotectedHeaders.decode(hex.decode(testVector['sign1::sign'].unprotectedHeaders.cborHex)),
         payload: hex.decode(testVector['sign1::sign'].payload),
         signature: cborDecode<Sign1>(hex.decode(testVector['sign1::sign'].expectedOutput.cborHex)).signature,

--- a/packages/cose/src/cose/headers/header-claims.ts
+++ b/packages/cose/src/cose/headers/header-claims.ts
@@ -1,0 +1,49 @@
+import z from 'zod'
+import { type TypedMap, typedMap } from '../../utils/typed-map.js'
+import { zUint8Array } from '../../utils/zod.js'
+import { RegisteredCwtHeaderClaimKey } from './defaults.js'
+
+/**
+ * Schema for the known COSE header claims (RFC 9052 Section 3.1 / the IANA COSE Header Parameters
+ * registry). Shared by the protected and unprotected header structures.
+ *
+ * `kid` (4) is typed as a bstr (`Uint8Array`): a header carrying a `kid` whose value is not a bstr
+ * (e.g. a malformed `{ 4: undefined }`) is rejected at decode for every Sign1-derived structure.
+ *
+ * The other registered labels are enumerated as known keys but left permissively typed (`unknown`)
+ * so that valid-but-variably-shaped encodings are not rejected. Additional (unregistered or
+ * private-use) labels are allowed through (`allowAdditionalKeys`).
+ */
+// Any defined (non-`undefined`) value. Apart from `kid`, the registered labels are enumerated as
+// known keys but not constrained to a specific value type (their CBOR shapes vary and we do not want
+// to reject valid encodings). Rejecting `undefined` both keeps a malformed `{ <label>: undefined }`
+// out and lets `.exactOptional()` correctly mark the key as optional.
+const zDefinedValue = z.unknown().refine((value) => value !== undefined)
+
+export const coseHeaderClaimsSchema = typedMap(
+  [
+    [RegisteredCwtHeaderClaimKey.Algorithm, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.Critical, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.ContentType, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.KeyId, zUint8Array.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.Iv, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.PartialIv, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5Bag, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5Chain, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5T, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5U, zDefinedValue.exactOptional()],
+  ] as const,
+  { allowAdditionalKeys: true }
+)
+
+export type CoseHeaderClaims = z.infer<typeof coseHeaderClaimsSchema>
+
+/**
+ * Read/write view over a COSE header map. `kid` (4) is typed as a bstr, while any other integer label
+ * remains accessible because COSE headers are open-ended (RFC 9052 / private-use range). The `kid`
+ * type is enforced at decode by `coseHeaderClaimsSchema`; this view only governs typed access.
+ */
+export type CoseHeaders = TypedMap<
+  { [RegisteredCwtHeaderClaimKey.KeyId]: Uint8Array } & Record<number, unknown>,
+  RegisteredCwtHeaderClaimKey.KeyId
+>

--- a/packages/cose/src/cose/headers/header-claims.ts
+++ b/packages/cose/src/cose/headers/header-claims.ts
@@ -3,47 +3,46 @@ import { type TypedMap, typedMap } from '../../utils/typed-map.js'
 import { zUint8Array } from '../../utils/zod.js'
 import { RegisteredCwtHeaderClaimKey } from './defaults.js'
 
-/**
- * Schema for the known COSE header claims (RFC 9052 Section 3.1 / the IANA COSE Header Parameters
- * registry). Shared by the protected and unprotected header structures.
- *
- * `kid` (4) is typed as a bstr (`Uint8Array`): a header carrying a `kid` whose value is not a bstr
- * (e.g. a malformed `{ 4: undefined }`) is rejected at decode for every Sign1-derived structure.
- *
- * The other registered labels are enumerated as known keys but left permissively typed (`unknown`)
- * so that valid-but-variably-shaped encodings are not rejected. Additional (unregistered or
- * private-use) labels are allowed through (`allowAdditionalKeys`).
- */
-// Any defined (non-`undefined`) value. Apart from `kid`, the registered labels are enumerated as
-// known keys but not constrained to a specific value type (their CBOR shapes vary and we do not want
-// to reject valid encodings). Rejecting `undefined` both keeps a malformed `{ <label>: undefined }`
-// out and lets `.exactOptional()` correctly mark the key as optional.
-const zDefinedValue = z.unknown().refine((value) => value !== undefined)
+// A COSE label is an integer (registry) or a text string (private use).
+const zCoseLabel = z.union([z.number(), z.string()])
+// COSE_X509: a single certificate (bstr) or a chain (array of bstr). Used by x5bag/x5chain.
+const zCertOrChain = z.union([zUint8Array, z.array(zUint8Array)])
 
+/**
+ * Schema for the known COSE header claims (RFC 9052 Section 3.1 / RFC 9360 / the IANA COSE Header
+ * Parameters registry). Shared by the protected and unprotected header structures.
+ *
+ * Each registered label is typed to its CBOR shape; in particular `kid` (4) is a bstr (`Uint8Array`),
+ * so a header carrying a `kid` whose value is not a bstr (e.g. a malformed `{ 4: undefined }`) is
+ * rejected at decode for every Sign1-derived structure. Additional (unregistered or private-use)
+ * labels are allowed through (`allowAdditionalKeys`).
+ */
 export const coseHeaderClaimsSchema = typedMap(
   [
-    [RegisteredCwtHeaderClaimKey.Algorithm, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.Critical, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.ContentType, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.Algorithm, zCoseLabel.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.Critical, z.array(zCoseLabel).exactOptional()],
+    [RegisteredCwtHeaderClaimKey.ContentType, zCoseLabel.exactOptional()],
     [RegisteredCwtHeaderClaimKey.KeyId, zUint8Array.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.Iv, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.PartialIv, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.X5Bag, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.X5Chain, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.X5T, zDefinedValue.exactOptional()],
-    [RegisteredCwtHeaderClaimKey.X5U, zDefinedValue.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.Iv, zUint8Array.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.PartialIv, zUint8Array.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5Bag, zCertOrChain.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5Chain, zCertOrChain.exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5T, z.array(z.unknown()).exactOptional()],
+    [RegisteredCwtHeaderClaimKey.X5U, z.string().exactOptional()],
   ] as const,
   { allowAdditionalKeys: true }
 )
 
 export type CoseHeaderClaims = z.infer<typeof coseHeaderClaimsSchema>
 
+// Widen a typed-map type to also allow access to any other integer label.
+type OpenIntegerKeys<T> =
+  T extends TypedMap<infer Schema, infer Optional> ? TypedMap<Schema & Record<number, unknown>, Optional> : never
+
 /**
- * Read/write view over a COSE header map. `kid` (4) is typed as a bstr, while any other integer label
- * remains accessible because COSE headers are open-ended (RFC 9052 / private-use range). The `kid`
- * type is enforced at decode by `coseHeaderClaimsSchema`; this view only governs typed access.
+ * Read/write view over a COSE header map: the typed claims above plus open access to any other
+ * integer label, because COSE headers are open-ended (unregistered and private-use labels are valid,
+ * e.g. a status list's `typ`). The typed claims are still validated at decode by
+ * `coseHeaderClaimsSchema`; this view only governs typed access.
  */
-export type CoseHeaders = TypedMap<
-  { [RegisteredCwtHeaderClaimKey.KeyId]: Uint8Array } & Record<number, unknown>,
-  RegisteredCwtHeaderClaimKey.KeyId
->
+export type CoseHeaders = OpenIntegerKeys<CoseHeaderClaims>

--- a/packages/cose/src/cose/headers/index.ts
+++ b/packages/cose/src/cose/headers/index.ts
@@ -1,3 +1,4 @@
 export * from './defaults'
+export * from './header-claims'
 export * from './protected-headers'
 export * from './unprotected-headers'

--- a/packages/cose/src/cose/headers/protected-headers.ts
+++ b/packages/cose/src/cose/headers/protected-headers.ts
@@ -1,18 +1,20 @@
 import z from 'zod'
 import { CborStructure } from '../../cbor/cbor-structure.js'
 import { cborDecode, cborEncode } from '../../cbor/parser.js'
+import { TypedMap } from '../../utils/typed-map.js'
 import { zUint8Array } from '../../utils/zod.js'
+import { type CoseHeaders, coseHeaderClaimsSchema } from './header-claims.js'
 
-// TODO: typedMap with known keys (Header enum)
-
+// Wire form: the header map is wrapped in a bstr (RFC 9052). `protectedHeadersDecodedStructure` is
+// the plain map carried inside that bstr, kept for backwards compatibility.
 export const protectedHeadersEncodedStructure = zUint8Array
 export const protectedHeadersDecodedStructure = z.map(z.number(), z.unknown())
 
-export type ProtectedHeadersDecodedStructure = z.infer<typeof protectedHeadersDecodedStructure>
 export type ProtectedHeadersEncodedStructure = z.infer<typeof protectedHeadersEncodedStructure>
+export type ProtectedHeadersDecodedStructure = z.infer<typeof coseHeaderClaimsSchema>
 
 export type ProtectedHeaderOptions = {
-  protectedHeaders?: ProtectedHeadersDecodedStructure
+  protectedHeaders?: Map<number, unknown>
 }
 
 export class ProtectedHeaders extends CborStructure<
@@ -20,18 +22,18 @@ export class ProtectedHeaders extends CborStructure<
   ProtectedHeadersDecodedStructure
 > {
   public static override get encodingSchema() {
-    return z.codec(protectedHeadersEncodedStructure, protectedHeadersDecodedStructure, {
+    return z.codec(protectedHeadersEncodedStructure, coseHeaderClaimsSchema.out, {
       // TODO: Senders SHOULD encode a zero-length map as a zero-length string rather than as a zero-length map
-      encode: (decoded) => cborEncode(decoded) as Uint8Array<ArrayBuffer>,
-      decode: (encoded) => cborDecode(encoded),
+      encode: (decoded) => cborEncode(decoded.toMap()) as Uint8Array<ArrayBuffer>,
+      decode: (encoded) => TypedMap.fromMap(cborDecode(encoded) as Map<number, unknown>),
     })
   }
 
-  public get headers() {
-    return this.structure
+  public get headers(): CoseHeaders {
+    return this.structure as unknown as CoseHeaders
   }
 
   public static create(options: ProtectedHeaderOptions) {
-    return ProtectedHeaders.fromDecodedStructure(options.protectedHeaders ?? new Map())
+    return ProtectedHeaders.fromDecodedStructure(TypedMap.fromMap(options.protectedHeaders ?? new Map()))
   }
 }

--- a/packages/cose/src/cose/headers/unprotected-headers.ts
+++ b/packages/cose/src/cose/headers/unprotected-headers.ts
@@ -1,24 +1,34 @@
 import z from 'zod'
 import { CborStructure } from '../../cbor/cbor-structure.js'
+import { TypedMap } from '../../utils/typed-map.js'
+import { type CoseHeaders, coseHeaderClaimsSchema } from './header-claims.js'
 
+// Wire form: a plain map of integer label -> value (used by the COSE_Sign1 encoded schema).
 export const unprotectedHeadersStructure = z.map(z.number(), z.unknown())
 
-export type UnprotectedHeadersStructure = z.infer<typeof unprotectedHeadersStructure>
+export type UnprotectedHeadersEncodedStructure = z.infer<typeof unprotectedHeadersStructure>
+export type UnprotectedHeadersDecodedStructure = z.infer<typeof coseHeaderClaimsSchema>
+
+// Backwards-compatible alias for the wire structure.
+export type UnprotectedHeadersStructure = UnprotectedHeadersEncodedStructure
 
 export type UnprotectedHeaderOptions = {
-  unprotectedHeaders?: UnprotectedHeadersStructure
+  unprotectedHeaders?: UnprotectedHeadersEncodedStructure
 }
 
-export class UnprotectedHeaders extends CborStructure<UnprotectedHeadersStructure> {
+export class UnprotectedHeaders extends CborStructure<
+  UnprotectedHeadersEncodedStructure,
+  UnprotectedHeadersDecodedStructure
+> {
   public static override get encodingSchema() {
-    return unprotectedHeadersStructure
+    return coseHeaderClaimsSchema
   }
 
-  public get headers() {
-    return this.structure
+  public get headers(): CoseHeaders {
+    return this.structure as unknown as CoseHeaders
   }
 
   public static create(options: UnprotectedHeaderOptions) {
-    return UnprotectedHeaders.fromDecodedStructure(options.unprotectedHeaders ?? new Map())
+    return UnprotectedHeaders.fromDecodedStructure(TypedMap.fromMap(options.unprotectedHeaders ?? new Map()))
   }
 }

--- a/packages/cose/src/cose/sign1.ts
+++ b/packages/cose/src/cose/sign1.ts
@@ -248,16 +248,12 @@ export class Sign1 extends CborStructure<Sign1EncodedStructure, Sign1DecodedStru
     const protectedHeaders =
       options.protectedHeaders instanceof ProtectedHeaders
         ? options.protectedHeaders
-        : options.protectedHeaders
-          ? ProtectedHeaders.fromDecodedStructure(options.protectedHeaders)
-          : ProtectedHeaders.create({})
+        : ProtectedHeaders.create({ protectedHeaders: options.protectedHeaders })
 
     const unprotectedHeaders =
       options.unprotectedHeaders instanceof UnprotectedHeaders
         ? options.unprotectedHeaders
-        : options.unprotectedHeaders
-          ? UnprotectedHeaders.fromDecodedStructure(options.unprotectedHeaders)
-          : UnprotectedHeaders.create({})
+        : UnprotectedHeaders.create({ unprotectedHeaders: options.unprotectedHeaders })
 
     // biome-ignore lint/complexity/noThisInStatic: this.create is intentional for subclass support
     const sign1 = new this({


### PR DESCRIPTION
## Summary

Fulfils the `// TODO: typedMap with known keys (Header enum)` in `protected-headers.ts`: the COSE header claims are now a `typedMap`, with `kid` (4) typed as a bstr (`Uint8Array`, `exactOptional`). A `kid` whose value is not a bstr (e.g. a malformed `{ 4: undefined }`) is now rejected at decode for **every** `Sign1`-derived structure, instead of being silently ignored. Other registered labels are enumerated as known keys; additional/private-use labels still pass through.

Follow-up to the review on openwallet-foundation-labs/mdoc-ts#208 (@TimoGlastra): "DeviceSignature = Sign1, which means we need to address this in identity-common-ts, then it will also be solved for ALL classes that extend it."

## Changes

- `coseHeaderClaimsSchema` (new `header-claims.ts`): typedMap of the registered header labels; `kid` strict bstr, others known-but-permissive, `allowAdditionalKeys`.
- `ProtectedHeaders` / `UnprotectedHeaders` back their structure with a `TypedMap`; the `.headers` accessor (`CoseHeaders`) types `kid` as a bstr while keeping open integer-label access (COSE headers are open-ended).
- `Sign1.create` routes header construction through `create()` (consistent with `Mac0`).
- Tests build headers via `create`; new `header-claims.test.ts`.

## Notes

Apart from `kid`, registered labels are left permissively typed (their CBOR shapes vary) — tightening them is a safe follow-up. The `.headers` view intentionally allows any integer label so consumers don't need casts for private-use / out-of-registry labels (e.g. status-list's `typ`=16).
