### PR TITLE
feat: make totalStatuses public readonly in StatusList

### DIFF
--- a/.changeset/odd-geckos-cough.md
+++ b/.changeset/odd-geckos-cough.md
@@ -1,0 +1,5 @@
+---
+"@owf/token-status-list": patch
+---
+
+feat: make totalStatuses public readonly in StatusList class

--- a/packages/token-status-list/src/status-list.ts
+++ b/packages/token-status-list/src/status-list.ts
@@ -8,7 +8,7 @@ import type { BitsPerStatus, StatusType } from './types'
 export class StatusList {
   private _statusList: Array<StatusType | number>
   private bitsPerStatus: BitsPerStatus
-  private totalStatuses: number
+  public readonly totalStatuses: number
   public aggregationUri?: string
 
   constructor(statusList: number[], bitsPerStatus: BitsPerStatus, aggregationUri?: string) {


### PR DESCRIPTION
We use this parameter internally, and now have to add `@ts-ignore` would be nice to have it public