### PR TITLE
feat(eudi-lote): improved errors with profile detail

### DIFF
--- a/.changeset/fine-ants-hang.md
+++ b/.changeset/fine-ants-hang.md
@@ -1,0 +1,5 @@
+---
+"@owf/eudi-lote": patch
+---
+
+Improve the error detail with profile information when validating a LoTE against a union of profiles.

--- a/packages/eudi-lote/src/validator.ts
+++ b/packages/eudi-lote/src/validator.ts
@@ -128,12 +128,19 @@ export function validateLoTEProfile(loteDocument: unknown, profile: LoTEProfile 
         path: 'LoTEType',
         message: `Document does not match any of the specified profiles: ${profiles.join(', ')}`,
       },
-      ...result.error.issues
-        .flatMap((issue) => (issue.code === 'invalid_union' ? issue.errors.flat() : [issue]))
-        .map((issue) => ({
-          path: issue.path.join('.'),
-          message: issue.message,
-        })),
+      ...result.error.issues.flatMap((issue) => {
+        if (issue.code === 'invalid_union') {
+          // `issue.errors` holds one array of issues per union branch, in the same order as `profiles`
+          return issue.errors.flatMap((branchIssues, index) =>
+            branchIssues.map((branchIssue) => ({
+              path: branchIssue.path.join('.'),
+              message: `Profile ${profiles[index]}: ${branchIssue.message}`,
+            }))
+          )
+        }
+
+        return [{ path: issue.path.join('.'), message: issue.message }]
+      }),
     ],
   }
 }


### PR DESCRIPTION
## Description

Improves the errors of the profile union with the profile name. This way, when checking against multiple profiles, we know which error applies to each profile.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [x] `@owf/eudi-lote`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)

## Example

Here's an example of an output with the current change:

```
[
  {
    path: 'LoTEType',
    message: 'Document does not match any of the specified profiles: EUPIDProvidersList, EUWRPACProvidersList'
  },
  {
    path: 'LoTE.ListAndSchemeInformation.SchemeTerritory',
    message: 'Profile EUPIDProvidersList: SchemeTerritory must be EU'
  },
  {
    path: 'LoTE.ListAndSchemeInformation.LoTEType',
    message: 'Profile EUWRPACProvidersList: LoTEType must be http://uri.etsi.org/19602/LoTEType/EUWRPACProvidersList'
  },
  {
    path: 'LoTE.ListAndSchemeInformation.StatusDeterminationApproach',
    message: 'Profile EUWRPACProvidersList: StatusDeterminationApproach must be http://uri.etsi.org/19602/WRPACProvidersList/StatusDetn/EU'
  },
  {
    path: 'LoTE.ListAndSchemeInformation.SchemeTerritory',
    message: 'Profile EUWRPACProvidersList: SchemeTerritory must be EU'
  },
  {
    path: 'LoTE.ListAndSchemeInformation.SchemeTypeCommunityRules',
    message: 'Profile EUWRPACProvidersList: SchemeTypeCommunityRules must contain a single element with uriValue of http://uri.etsi.org/19602/WRPACProvidersList/schemerules/EU'
  },
  {
    path: 'LoTE.TrustedEntitiesList.0.TrustedEntityInformation.TEInformationURI',
    message: 'Profile EUWRPACProvidersList: Each TrustedEntityInformation.TEInformationURI must contain at least one URI starting with http://uri.etsi.org/19602/ListOfTrustedEntities/WRPACProvider/'
  },
  {
    path: 'LoTE.TrustedEntitiesList.0.TrustedEntityServices.0.ServiceInformation.ServiceTypeIdentifier',
    message: 'Profile EUWRPACProvidersList: ServiceTypeIdentifier must be one of the following: http://uri.etsi.org/19602/SvcType/WRPAC/Issuance, http://uri.etsi.org/19602/SvcType/WRPAC/Revocation'
  }
]
```