### PR TITLE
fix(token-status-list): verify StatusListCwt with original COSE payload bytes

### DIFF
--- a/.changeset/eighty-ghosts-thank.md
+++ b/.changeset/eighty-ghosts-thank.md
@@ -1,0 +1,5 @@
+---
+"@owf/token-status-list": patch
+---
+
+fix bug for payload verification

--- a/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.ts
+++ b/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.ts
@@ -454,6 +454,30 @@ suite('StatusListCwt', () => {
       const result = await decodedStatusListCwt.verifySignature({ key: wrongKey }, sign1Context)
       expect(result).toBe(false)
     })
+
+    test('should verify against original token payload bytes instead of re-encoded payload bytes', async () => {
+      const statusListCwt = StatusListCwt.createFromStatusListAndSubject(
+        { statusList: [0, 1, 0], bitsPerStatus: 1 },
+        'did:test'
+      )
+
+      const token = await statusListCwt.signAndEncode(
+        { signingKey: signKey, algorithm: SignatureAlgorithm.ES256 },
+        sign1Context
+      )
+
+      const decodedStatusListCwt = StatusListCwt.fromToken(token)
+      const originalEncode = decodedStatusListCwt.payload.encode.bind(decodedStatusListCwt.payload)
+      ;(decodedStatusListCwt.payload as unknown as { encode: () => Uint8Array }).encode = () => {
+        const payload = originalEncode()
+        const tampered = new Uint8Array(payload)
+        tampered[tampered.length - 1] ^= 0x01
+        return tampered
+      }
+
+      const result = await decodedStatusListCwt.verifySignature({ key: signKey }, sign1Context)
+      expect(result).toBe(true)
+    })
   })
 
   suite('verifyAuthenticationCode', () => {
@@ -482,6 +506,27 @@ suite('StatusListCwt', () => {
       const wrongKey = CoseKey.create({ keyType: KeyType.Oct, k: new TextEncoder().encode('wrong-key') })
       const result = await decodedStatusListCwt.verifyAuthenticationCode({ key: wrongKey }, mac0Context)
       expect(result).toBe(false)
+    })
+
+    test('should verify MAC against original token payload bytes instead of re-encoded payload bytes', async () => {
+      const statusListCwt = StatusListCwt.createFromStatusListAndSubject(
+        { statusList: [0, 1, 0], bitsPerStatus: 1 },
+        'did:test'
+      )
+
+      const token = await statusListCwt.authenticateAndEncode({ key: macKey }, mac0Context)
+
+      const decodedStatusListCwt = StatusListCwt.fromToken(token)
+      const originalEncode = decodedStatusListCwt.payload.encode.bind(decodedStatusListCwt.payload)
+      ;(decodedStatusListCwt.payload as unknown as { encode: () => Uint8Array }).encode = () => {
+        const payload = originalEncode()
+        const tampered = new Uint8Array(payload)
+        tampered[tampered.length - 1] ^= 0x01
+        return tampered
+      }
+
+      const result = await decodedStatusListCwt.verifyAuthenticationCode({ key: macKey }, mac0Context)
+      expect(result).toBe(true)
     })
   })
 })

--- a/packages/token-status-list/src/cbor/status-list-cwt.ts
+++ b/packages/token-status-list/src/cbor/status-list-cwt.ts
@@ -21,6 +21,7 @@ export type StatusListCwtOptions = {
   protectedHeaders?: ProtectedHeaders | ProtectedHeaderOptions['protectedHeaders']
   unprotectedHeaders?: UnprotectedHeaders | UnprotectedHeaderOptions['unprotectedHeaders']
   signatureOrTag?: Uint8Array
+  originalPayloadBytes?: Uint8Array
 }
 
 export enum StatusListCwtHeaderKey {
@@ -32,6 +33,7 @@ export class StatusListCwt {
   public protectedHeaders?: ProtectedHeaders
   public unprotectedHeaders?: UnprotectedHeaders
   private signatureOrTag?: Uint8Array
+  private originalPayloadBytes?: Uint8Array
 
   public constructor(options: StatusListCwtOptions) {
     this.payload =
@@ -46,6 +48,7 @@ export class StatusListCwt {
         : UnprotectedHeaders.create({ unprotectedHeaders: options.unprotectedHeaders })
 
     this.signatureOrTag = options.signatureOrTag
+    this.originalPayloadBytes = options.originalPayloadBytes
 
     if (this.protectedHeaders.headers.get(StatusListCwtHeaderKey.Typ) === undefined) {
       this.protectedHeaders.headers.set(StatusListCwtHeaderKey.Typ, MediaTypes.StatusListCwt)
@@ -54,10 +57,12 @@ export class StatusListCwt {
 
   public setStatusList(statusList: StatusList | StatusListCbor) {
     this.payload.setStatusList(statusList)
+    this.originalPayloadBytes = undefined
   }
 
   public updateStatusList(index: number, value: number) {
     this.payload.statusList.setStatus(index, value)
+    this.originalPayloadBytes = undefined
   }
 
   /**
@@ -99,6 +104,7 @@ export class StatusListCwt {
       protectedHeaders: cwt.protectedHeaders,
       unprotectedHeaders: cwt.unprotectedHeaders,
       signatureOrTag: cwt.signatureOrTag,
+      originalPayloadBytes: new Uint8Array(cwt.payload),
     })
   }
 
@@ -166,7 +172,7 @@ export class StatusListCwt {
     const cwt = new Cwt({
       protectedHeaders: this.protectedHeaders,
       unprotectedHeaders: this.unprotectedHeaders,
-      payload: this.payload.encode(),
+      payload: this.originalPayloadBytes ?? this.payload.encode(),
       signature: this.signatureOrTag,
     })
 
@@ -177,7 +183,7 @@ export class StatusListCwt {
     const cwt = new Cwt({
       protectedHeaders: this.protectedHeaders,
       unprotectedHeaders: this.unprotectedHeaders,
-      payload: this.payload.encode(),
+      payload: this.originalPayloadBytes ?? this.payload.encode(),
       tag: this.signatureOrTag,
     })
 


### PR DESCRIPTION
## Description

Fixes StatusListCwt signature/MAC verification to use the original payload bytes parsed from the incoming COSE/CWT token, instead of re-encoding the decoded payload structure.

This aligns verification behavior with COSE `Sig_structure` / `MAC_structure` payload handling (`payload` as `bstr`) and prevents false negatives when semantically equivalent payload content is encoded with different valid binary representations (for example different zlib headers/compression outputs).

The change also clears cached original payload bytes when payload content is mutated through StatusListCwt mutators.

Added regression tests for both Sign1 and Mac0 verification paths.

## Related Issue

Fixes #132

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/identity-common`
- [x] Other: `@owf/token-status-list`

## Checklist

- [x] My code follows the project's coding standards
- [ ] I have run `pnpm style:fix` to format my code
- [ ] I have run `pnpm types:check` and there are no errors
- [ ] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] I have created a changeset (if this affects published packages)

## Testing

- `pnpm --filter @owf/token-status-list test`
- Result: 5 files passed, 129 tests passed

## Screenshots (if applicable)

N/A

## Additional Notes

Regression tests were added to ensure verification succeeds even if `payload.encode()` would return different bytes than the originally signed/authenticated payload in the received token.