### PR TITLE
feat(eudi-lote): improved lote profile validation errors

### DIFF
--- a/.changeset/spicy-beans-relate.md
+++ b/.changeset/spicy-beans-relate.md
@@ -1,0 +1,8 @@
+---
+"@owf/eudi-lote": patch
+---
+
+Simplifies the errors returned by `validateLoTEProfile` by pre-matching the given LoTE to the corresponding profiles' type identifiers:
+
+- When no type matches, the error clearly states that the LoTE Type doesn't match any of the given profiles.
+- When one type matches, but fails along the verification, only the errors of this profile are returned for clarity.

--- a/packages/eudi-lote/src/__tests__/validator.test.mts
+++ b/packages/eudi-lote/src/__tests__/validator.test.mts
@@ -468,5 +468,56 @@ describe('LoTE Validator', () => {
 
       expect(result.valid).toBe(true)
     })
+
+    it('short-circuit errors when validating against wrong profile', () => {
+      const { payload: lote } = decodeJwt(WRPACProvidersJWT)
+      const result = validateLoTEProfile(lote, [LoTEProfile.EUPIDProvidersList, LoTEProfile.EUWalletProvidersList])
+
+      expect(result.valid).toBe(false)
+      expect(result.errors).toEqual([
+        {
+          message: 'Document does not match any of the specified profiles: EUPIDProvidersList, EUWalletProvidersList',
+          path: 'LoTEType',
+        },
+        {
+          message: 'Profile EUPIDProvidersList: LoTEType must be http://uri.etsi.org/19602/LoTEType/EUPIDProvidersList',
+          path: 'LoTE.ListAndSchemeInformation.LoTEType',
+        },
+        {
+          message:
+            'Profile EUWalletProvidersList: LoTEType must be http://uri.etsi.org/19602/LoTEType/EUWalletProvidersList',
+          path: 'LoTE.ListAndSchemeInformation.LoTEType',
+        },
+      ])
+    })
+
+    it('only includes errors for matched LoTEProfile', () => {
+      const { payload: lote } = decodeJwt<any, LoTEDocument>(WRPACProvidersJWT)
+
+      lote.LoTE.ListAndSchemeInformation.StatusDeterminationApproach = 'invalid'
+
+      const result = validateLoTEProfile(lote, [
+        LoTEProfile.EUPIDProvidersList,
+        LoTEProfile.EUWalletProvidersList,
+        LoTEProfile.EUWRPACProvidersList,
+      ])
+
+      expect(result.valid).toBe(false)
+      expect(result.errors).toEqual([
+        {
+          message: 'Document does not match profile EUWRPACProvidersList',
+          path: 'LoTEType',
+        },
+        {
+          message: 'Profile EUWRPACProvidersList: Invalid URL',
+          path: 'LoTE.ListAndSchemeInformation.StatusDeterminationApproach',
+        },
+        {
+          message:
+            'Profile EUWRPACProvidersList: StatusDeterminationApproach must be http://uri.etsi.org/19602/WRPACProvidersList/StatusDetn/EU',
+          path: 'LoTE.ListAndSchemeInformation.StatusDeterminationApproach',
+        },
+      ])
+    })
   })
 })

--- a/packages/eudi-lote/src/profiles.ts
+++ b/packages/eudi-lote/src/profiles.ts
@@ -11,6 +11,16 @@ import type { LoTEDocument } from './types'
 
 const SIX_MONTHS_IN_MS = 6 * 31 * 24 * 60 * 60 * 1000
 
+export const LOTE_TYPES = {
+  EUPIDProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUPIDProvidersList',
+  EUWalletProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUWalletProvidersList',
+  EUWRPACProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUWRPACProvidersList',
+  EUWRPRCProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUWRPRCProvidersList',
+  EUEAAProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUEAAProvidersList',
+  EUPubEAAProvidersList: 'http://uri.etsi.org/19602/LoTEType/EUPubEAAProvidersList',
+  mDLProvidersList: 'http://trust.ec.europa.eu/lists/mDL/mDLProvidersListType',
+} as const
+
 type ListAndSchemeInformationRefinementOptions = {
   loTEType: string
   loTEVersionIdentifier: number
@@ -197,7 +207,7 @@ const trustedEntitiesListRefinement =
 // ETSI TS 119 602 D
 export const EUPIDProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUPIDProvidersList',
+    loTEType: LOTE_TYPES.EUPIDProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/PIDProvidersList/StatusDetn/EU',
     schemeTerritory: 'EU',
@@ -217,7 +227,7 @@ export const EUPIDProvidersListSchema = LoTEDocumentSchema.superRefine(
 // ETSI TS 119 602 E
 export const EUWalletProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUWalletProvidersList',
+    loTEType: LOTE_TYPES.EUWalletProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/WalletProvidersList/StatusDetn/EU',
     schemeTerritory: 'EU',
@@ -237,7 +247,7 @@ export const EUWalletProvidersListSchema = LoTEDocumentSchema.superRefine(
 // ETSI TS 119 602 F
 export const EUWRPACProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUWRPACProvidersList',
+    loTEType: LOTE_TYPES.EUWRPACProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/WRPACProvidersList/StatusDetn/EU',
     schemeTerritory: 'EU',
@@ -257,7 +267,7 @@ export const EUWRPACProvidersListSchema = LoTEDocumentSchema.superRefine(
 // ETSI TS 119 602 G
 export const EUWRPRCProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUWRPRCProvidersList',
+    loTEType: LOTE_TYPES.EUWRPRCProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/WRPRCrovidersList/StatusDetn/EU',
     schemeTerritory: 'EU',
@@ -276,7 +286,7 @@ export const EUWRPRCProvidersListSchema = LoTEDocumentSchema.superRefine(
 
 export const EUEAAProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUEAAProvidersList',
+    loTEType: LOTE_TYPES.EUEAAProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/EAAProvidersList/StatusDetn/EU"',
     schemeTerritory: 'EU',
@@ -296,7 +306,7 @@ export const EUEAAProvidersListSchema = LoTEDocumentSchema.superRefine(
 // ETSI TS 119 602 H
 export const EUPubEAAProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://uri.etsi.org/19602/LoTEType/EUPubEAAProvidersList',
+    loTEType: LOTE_TYPES.EUPubEAAProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://uri.etsi.org/19602/PubEAAProvidersList/StatusDetn/EU"',
     schemeTerritory: 'EU',
@@ -317,7 +327,7 @@ export const EUPubEAAProvidersListSchema = LoTEDocumentSchema.superRefine(
 // mDL Providers List
 export const mDLProvidersListSchema = LoTEDocumentSchema.superRefine(
   listAndSchemeInformationRefinement({
-    loTEType: 'http://trust.ec.europa.eu/lists/mDL/mDLProvidersListType',
+    loTEType: LOTE_TYPES.mDLProvidersList,
     loTEVersionIdentifier: 1,
     statusDeterminationApproach: 'http://trust.ec.europa.eu/lists/mDL/mDLProvidersListStatusDetn',
     schemeTerritory: 'EU',

--- a/packages/eudi-lote/src/validator.ts
+++ b/packages/eudi-lote/src/validator.ts
@@ -4,7 +4,7 @@
  * Runtime validation for ETSI TS 119 602 LoTE documents using Zod schemas.
  */
 
-import z from 'zod'
+import type z from 'zod'
 import { LoTEException } from './lote-exception'
 import {
   EUEAAProvidersListSchema,
@@ -13,6 +13,7 @@ import {
   EUWalletProvidersListSchema,
   EUWRPACProvidersListSchema,
   EUWRPRCProvidersListSchema,
+  LOTE_TYPES,
   mDLProvidersListSchema,
 } from './profiles'
 import { LoTEDocumentSchema } from './schemas'
@@ -94,14 +95,30 @@ export enum LoTEProfile {
   mDLProvidersList = 'mDLProvidersList',
 }
 
-const profileToSchemaMap: Record<LoTEProfile, z.ZodType> = {
-  [LoTEProfile.EUPIDProvidersList]: EUPIDProvidersListSchema,
-  [LoTEProfile.EUWalletProvidersList]: EUWalletProvidersListSchema,
-  [LoTEProfile.EUWRPACProvidersList]: EUWRPACProvidersListSchema,
-  [LoTEProfile.EUWRPRCProvidersList]: EUWRPRCProvidersListSchema,
-  [LoTEProfile.EUEAAProvidersList]: EUEAAProvidersListSchema,
-  [LoTEProfile.EUPubEAAProvidersList]: EUPubEAAProvidersListSchema,
-  [LoTEProfile.mDLProvidersList]: mDLProvidersListSchema,
+const profileConfig: Record<LoTEProfile, { loTEType: string; schema: z.ZodType }> = {
+  [LoTEProfile.EUPIDProvidersList]: { loTEType: LOTE_TYPES.EUPIDProvidersList, schema: EUPIDProvidersListSchema },
+  [LoTEProfile.EUWalletProvidersList]: {
+    loTEType: LOTE_TYPES.EUWalletProvidersList,
+    schema: EUWalletProvidersListSchema,
+  },
+  [LoTEProfile.EUWRPACProvidersList]: { loTEType: LOTE_TYPES.EUWRPACProvidersList, schema: EUWRPACProvidersListSchema },
+  [LoTEProfile.EUWRPRCProvidersList]: { loTEType: LOTE_TYPES.EUWRPRCProvidersList, schema: EUWRPRCProvidersListSchema },
+  [LoTEProfile.EUEAAProvidersList]: { loTEType: LOTE_TYPES.EUEAAProvidersList, schema: EUEAAProvidersListSchema },
+  [LoTEProfile.EUPubEAAProvidersList]: {
+    loTEType: LOTE_TYPES.EUPubEAAProvidersList,
+    schema: EUPubEAAProvidersListSchema,
+  },
+  [LoTEProfile.mDLProvidersList]: { loTEType: LOTE_TYPES.mDLProvidersList, schema: mDLProvidersListSchema },
+}
+
+function getDocumentLoTEType(loteDocument: unknown): string | undefined {
+  try {
+    const type = (loteDocument as { LoTE?: { ListAndSchemeInformation?: { LoTEType?: unknown } } } | null | undefined)
+      ?.LoTE?.ListAndSchemeInformation?.LoTEType
+    return typeof type === 'string' ? type : undefined
+  } catch {
+    return undefined
+  }
 }
 
 /**
@@ -114,13 +131,31 @@ const profileToSchemaMap: Record<LoTEProfile, z.ZodType> = {
  */
 export function validateLoTEProfile(loteDocument: unknown, profile: LoTEProfile | LoTEProfile[]): ValidationResult {
   const profiles = Array.isArray(profile) ? profile : [profile]
-  const schema = z.union(profiles.map((p) => profileToSchemaMap[p]))
-  const result = schema.safeParse(loteDocument)
+  const documentLoTEType = getDocumentLoTEType(loteDocument)
 
-  if (result.success) {
-    return { valid: true, errors: [] }
+  // LoTEType is unique per profile, so at most one requested profile can match.
+  const matchedProfile = profiles.find((p) => profileConfig[p].loTEType === documentLoTEType)
+
+  if (matchedProfile) {
+    const result = profileConfig[matchedProfile].schema.safeParse(loteDocument)
+
+    if (result.success) {
+      return { valid: true, errors: [] }
+    }
+
+    return {
+      valid: false,
+      errors: [
+        { path: 'LoTEType', message: `Document does not match profile ${matchedProfile}` },
+        ...result.error.issues.map((issue) => ({
+          path: issue.path.join('.'),
+          message: `Profile ${matchedProfile}: ${issue.message}`,
+        })),
+      ],
+    }
   }
 
+  // No requested profile matches the document's LoTEType.
   return {
     valid: false,
     errors: [
@@ -128,19 +163,10 @@ export function validateLoTEProfile(loteDocument: unknown, profile: LoTEProfile 
         path: 'LoTEType',
         message: `Document does not match any of the specified profiles: ${profiles.join(', ')}`,
       },
-      ...result.error.issues.flatMap((issue) => {
-        if (issue.code === 'invalid_union') {
-          // `issue.errors` holds one array of issues per union branch, in the same order as `profiles`
-          return issue.errors.flatMap((branchIssues, index) =>
-            branchIssues.map((branchIssue) => ({
-              path: branchIssue.path.join('.'),
-              message: `Profile ${profiles[index]}: ${branchIssue.message}`,
-            }))
-          )
-        }
-
-        return [{ path: issue.path.join('.'), message: issue.message }]
-      }),
+      ...profiles.map((p) => ({
+        path: 'LoTE.ListAndSchemeInformation.LoTEType',
+        message: `Profile ${p}: LoTEType must be ${profileConfig[p].loTEType}`,
+      })),
     ],
   }
 }


### PR DESCRIPTION
## Description

Simplifies the errors returned by `validateLoTEProfile` by pre-matching the given LoTE to the corresponding profiles' type identifiers:

- When no type matches, the error clearly states that the LoTE Type doesn't match any of the given profiles.
- When one type matches, but fails along the verification, only the errors of this profile are returned for clarity.


## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [x] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x]  I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)
