### PR TITLE
fix: status list cwt original payload verification 

### DIFF
--- a/.changeset/olive-jars-shave.md
+++ b/.changeset/olive-jars-shave.md
@@ -1,0 +1,10 @@
+---
+"@owf/token-status-list": patch
+---
+
+Keep the `lst` claim of a status list compressed in `StatusListCbor`, so a decoded status list re-encodes to the bytes it was decoded from. DEFLATE has no canonical form, so inflating and deflating again is not guaranteed to reproduce the issuer's stream.
+
+This also fixes two related bugs in the same structure:
+
+- `aggregation_uri` was effectively required, so a status list that omits the claim could not be decoded at all.
+- `aggregation_uri` was written with an explicit `undefined` value when no aggregation uri was set, instead of the key being omitted. Status lists encoding the claim that way (including ones this library issued up to 0.3.1) are now rejected on decode.

--- a/packages/token-status-list/src/__tests__/cbor/status-list-cbor.round-trip.test.ts
+++ b/packages/token-status-list/src/__tests__/cbor/status-list-cbor.round-trip.test.ts
@@ -1,0 +1,124 @@
+import { cborDecode, cborEncode } from '@owf/cose'
+import { deflate } from 'pako'
+import { expect, suite, test } from 'vitest'
+import { StatusListCbor } from '../../cbor/status-list-cbor'
+import { StatusList } from '../../status-list'
+
+/**
+ * A status list as some other issuer would send it: `lst` compressed at the zlib default level
+ * (`78 9c`) rather than at level 9 (`78 da`), which is what this library compresses at.
+ */
+const foreignStatusList = (entries: Array<[string, unknown]>) => cborEncode(new Map(entries))
+
+const hex = (bytes: Uint8Array) => Buffer.from(bytes).toString('hex')
+
+const defaultLevelLst = deflate(new StatusList([0, 1, 0, 1, 0, 0, 0, 0], 1).encodeStatusListIntoByteArray())
+
+suite('StatusListCbor round trip', () => {
+  test('re-encodes a foreign status list to the exact bytes it was decoded from', () => {
+    // Guards the actual reported bug: the issuer signed over `78 9c`, so re-compressing at level 9
+    // would produce `78 da` and invalidate their signature.
+    expect(hex(defaultLevelLst.slice(0, 2))).toBe('789c')
+
+    const original = foreignStatusList([
+      ['bits', 1],
+      ['lst', defaultLevelLst],
+      ['aggregation_uri', 'https://example.com/aggregate'],
+    ])
+
+    expect(hex(StatusListCbor.decode(original).encode())).toEqual(hex(original))
+  })
+
+  test('preserves the key order it decoded, rather than imposing its own', () => {
+    const original = foreignStatusList([
+      ['aggregation_uri', 'https://example.com/aggregate'],
+      ['lst', defaultLevelLst],
+      ['bits', 1],
+    ])
+
+    expect(hex(StatusListCbor.decode(original).encode())).toEqual(hex(original))
+  })
+
+  test('reading the status list does not disturb the compressed bytes', () => {
+    const statusListCbor = StatusListCbor.decode(
+      foreignStatusList([
+        ['bits', 1],
+        ['lst', defaultLevelLst],
+      ])
+    )
+
+    expect(statusListCbor.statusList.getStatus(1)).toBe(1)
+    expect(hex(statusListCbor.compressedStatusList)).toEqual(hex(defaultLevelLst))
+  })
+
+  test('decodes a status list that omits aggregation_uri', () => {
+    const statusListCbor = StatusListCbor.decode(
+      foreignStatusList([
+        ['bits', 1],
+        ['lst', defaultLevelLst],
+      ])
+    )
+
+    expect(statusListCbor.aggregationUri).toBeUndefined()
+    expect(statusListCbor.statusList.statusList.slice(0, 4)).toEqual([0, 1, 0, 1])
+  })
+
+  test('rejects a status list that encodes aggregation_uri as undefined', () => {
+    // Emitted by this library up to and including 0.3.1, but not a valid encoding of an absent
+    // claim, so it is rejected rather than accommodated.
+    expect(() =>
+      StatusListCbor.decode(
+        foreignStatusList([
+          ['bits', 1],
+          ['lst', defaultLevelLst],
+          ['aggregation_uri', undefined],
+        ])
+      )
+    ).toThrow('Error decoding StatusListCbor')
+  })
+
+  test('omits aggregation_uri entirely when it is not set', () => {
+    const encoded = StatusListCbor.create({ bits: 1, list: [0, 1, 0] }).encode()
+
+    expect(Array.from(cborDecode<Map<string, unknown>>(encoded).keys())).toEqual(['bits', 'lst'])
+  })
+
+  test('keeps already compressed bytes passed to create as they are', () => {
+    const statusListCbor = StatusListCbor.create({ bits: 1, list: defaultLevelLst })
+
+    expect(hex(statusListCbor.compressedStatusList)).toEqual(hex(defaultLevelLst))
+  })
+
+  test('rejects bytes passed to create that are not a compressed status list', () => {
+    expect(() => StatusListCbor.create({ bits: 1, list: new Uint8Array([0, 1, 2, 3]) })).toThrow('Decompression failed')
+  })
+
+  suite('after modification', () => {
+    test('compresses again when modified through the status list cbor', () => {
+      const statusListCbor = StatusListCbor.decode(
+        foreignStatusList([
+          ['bits', 1],
+          ['lst', defaultLevelLst],
+        ])
+      )
+
+      statusListCbor.setStatus(0, 1)
+
+      expect(hex(statusListCbor.compressedStatusList)).not.toEqual(hex(defaultLevelLst))
+      expect(StatusListCbor.decode(statusListCbor.encode()).statusList.statusList.slice(0, 4)).toEqual([1, 1, 0, 1])
+    })
+
+    test('compresses again when modified through the inflated status list', () => {
+      const statusListCbor = StatusListCbor.decode(
+        foreignStatusList([
+          ['bits', 1],
+          ['lst', defaultLevelLst],
+        ])
+      )
+
+      statusListCbor.statusList.setStatus(0, 1)
+
+      expect(StatusListCbor.decode(statusListCbor.encode()).statusList.statusList.slice(0, 4)).toEqual([1, 1, 0, 1])
+    })
+  })
+})

--- a/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.ts
+++ b/packages/token-status-list/src/__tests__/cbor/status-list-cwt.test.ts
@@ -1,12 +1,21 @@
-import { CoseKey, cborEncode, KeyType, Sign1, SignatureAlgorithm } from '@owf/cose'
+import {
+  CoseKey,
+  cborEncode,
+  KeyType,
+  RegisteredCwtClaimKey,
+  RegisteredCwtHeaderClaimKey,
+  Sign1,
+  SignatureAlgorithm,
+} from '@owf/cose'
 import { Tag } from 'cbor-x'
+import { deflate } from 'pako'
 import { expect, suite, test } from 'vitest'
 import { StatusListCbor } from '../../cbor/status-list-cbor'
 import { StatusListCwt, StatusListCwtHeaderKey } from '../../cbor/status-list-cwt'
-import { StatusListCwtPayload } from '../../cbor/status-list-cwt-payload'
+import { StatusListCwtClaimKey, StatusListCwtPayload } from '../../cbor/status-list-cwt-payload'
 import { StatusList } from '../../status-list'
 import { SLException } from '../../status-list-exception'
-import { StatusType } from '../../types'
+import { MediaTypes, StatusType } from '../../types'
 import { mac0Context, macKey, sign1Context, signKey } from '../context'
 
 suite('StatusListCwt', () => {
@@ -509,6 +518,48 @@ suite('StatusListCwt', () => {
 
       const result = await decodedStatusListCwt.verifySignature({ key: wrongKey }, sign1Context)
       expect(result).toBe(false)
+    })
+
+    test('should verify a status list whose lst was not compressed at the level this library uses', async () => {
+      // The reported bug: an issuer compressed `lst` at the zlib default level (`78 9c`) and signed
+      // over those bytes, while we re-compressed at level 9 (`78 da`) before verifying. Build the
+      // token straight from the COSE primitives, so none of the status list classes get a chance to
+      // normalise the compression on the way in.
+      const foreignLst = deflate(new StatusList([0, 1, 0, 0, 0, 0, 0, 0], 1).encodeStatusListIntoByteArray())
+      expect(Buffer.from(foreignLst.slice(0, 2)).toString('hex')).toBe('789c')
+
+      const foreignPayload = cborEncode(
+        new Map<number, unknown>([
+          [RegisteredCwtClaimKey.Subject, 'did:test'],
+          [RegisteredCwtClaimKey.IssuedAt, Math.floor(Date.now() / 1000)],
+          [
+            StatusListCwtClaimKey.StatusList,
+            new Map<string, unknown>([
+              ['bits', 1],
+              ['lst', foreignLst],
+            ]),
+          ],
+        ])
+      )
+
+      const token = (
+        await Sign1.create({
+          protectedHeaders: new Map<number, unknown>([
+            [RegisteredCwtHeaderClaimKey.Algorithm, SignatureAlgorithm.ES256],
+            [StatusListCwtHeaderKey.Typ, MediaTypes.StatusListCwt],
+          ]),
+          payload: foreignPayload,
+        }).sign({ signingKey: signKey, algorithm: SignatureAlgorithm.ES256 }, sign1Context)
+      ).encode()
+
+      const decodedStatusListCwt = StatusListCwt.fromToken(token)
+      expect(await decodedStatusListCwt.verifySignature({ key: signKey }, sign1Context)).toBe(true)
+      expect(decodedStatusListCwt.payload.statusList.getStatus(1)).toBe(1)
+
+      // Not merely retained: the decoded payload also re-encodes to the issuer's exact bytes.
+      expect(Buffer.from(decodedStatusListCwt.payload.encode()).toString('hex')).toBe(
+        Buffer.from(foreignPayload).toString('hex')
+      )
     })
 
     test('should verify against original token payload bytes instead of re-encoded payload bytes', async () => {

--- a/packages/token-status-list/src/cbor/status-list-cbor.ts
+++ b/packages/token-status-list/src/cbor/status-list-cbor.ts
@@ -1,18 +1,18 @@
 import { CborStructure, TypedMap, typedMap, zUint8Array } from '@owf/cose'
 import { z } from 'zod'
 import { StatusList } from '../status-list'
-import type { BitsPerStatus } from '../types'
+import type { BitsPerStatus, StatusType } from '../types'
 
-export const statusListCborEncodedSchema = typedMap([
+export const statusListCborSchema = typedMap([
   ['bits', z.union([z.literal(1), z.literal(2), z.literal(4), z.literal(8)])],
   ['lst', zUint8Array],
-  ['aggregation_uri', z.string().optional()],
+  // NOTE: `exactOptional`, so that the key is omitted when there is no aggregation uri, rather than
+  // written with an `undefined` value, which is not a valid encoding of an absent claim.
+  ['aggregation_uri', z.string().exactOptional()],
 ])
 
-export const statusListCborDecodedSchema = z.instanceof(StatusList)
-
-export type StatusListCborEncodedStructure = z.infer<typeof statusListCborEncodedSchema>
-export type StatusListCborDecodedStructure = z.infer<typeof statusListCborDecodedSchema>
+export type StatusListCborEncodedStructure = z.input<typeof statusListCborSchema>
+export type StatusListCborDecodedStructure = z.output<typeof statusListCborSchema>
 
 export type CreateStatusListCborOptions = {
   bits: BitsPerStatus
@@ -25,35 +25,95 @@ export type StatusListCborWithStatusListOptions = {
 }
 
 export class StatusListCbor extends CborStructure<StatusListCborEncodedStructure, StatusListCborDecodedStructure> {
-  public statusList = this.structure
+  /**
+   * Lazily inflated view of `lst`. The compressed bytes in the structure stay authoritative: DEFLATE
+   * has no canonical form, so compressing this list again is not guaranteed to reproduce the bytes
+   * we decoded (the issuer may have used a different compression level or implementation), and a
+   * status list token is signed over those exact bytes.
+   */
+  #statusList?: StatusList
 
   public static override get encodingSchema() {
-    return z.codec(statusListCborEncodedSchema, statusListCborDecodedSchema, {
-      encode: (statusList) => {
-        return new TypedMap([
-          ['bits', statusList.getBitsPerStatus()],
-          ['lst', statusList.compressStatusListToBytes()],
-          ['aggregation_uri', statusList.aggregationUri],
-        ]) satisfies StatusListCborEncodedStructure
-      },
-      decode: (input) => {
-        return StatusList.decompressStatusListFromBytes(
-          input.get('lst'),
-          input.get('bits'),
-          input.get('aggregation_uri')
-        )
-      },
-    })
+    return statusListCborSchema
+  }
+
+  public get bits(): BitsPerStatus {
+    return this.structure.get('bits')
+  }
+
+  public get aggregationUri() {
+    return this.structure.get('aggregation_uri')
+  }
+
+  /** The compressed `lst` bytes, as decoded or created, unless the status list has been modified. */
+  public get compressedStatusList() {
+    this.compressStatusListIfModified()
+    return this.structure.get('lst')
+  }
+
+  public get statusList(): StatusList {
+    if (!this.#statusList) {
+      this.#statusList = StatusList.decompressStatusListFromBytes(
+        this.structure.get('lst'),
+        this.structure.get('bits'),
+        this.structure.get('aggregation_uri')
+      )
+    }
+
+    return this.#statusList
+  }
+
+  public setStatus(index: number, value: StatusType | number) {
+    this.statusList.setStatus(index, value)
+  }
+
+  public override get encodedStructure(): StatusListCborEncodedStructure {
+    this.compressStatusListIfModified()
+    return super.encodedStructure
+  }
+
+  /**
+   * Compress `lst` again only once the inflated list has actually been modified, so an untouched
+   * status list keeps the bytes it was decoded from. `Map.set` on an existing key keeps its
+   * position, so the decoded key order survives.
+   */
+  private compressStatusListIfModified() {
+    if (!this.#statusList?.isModified) return
+
+    this.structure.set('lst', this.#statusList.compressStatusListToBytes())
   }
 
   public static create(options: CreateStatusListCborOptions | StatusListCborWithStatusListOptions) {
-    const statusList =
-      'statusList' in options
-        ? options.statusList
-        : options.list instanceof Uint8Array
-          ? StatusList.decompressStatusListFromBytes(options.list, options.bits, options.aggregationUri)
-          : new StatusList(options.list, options.bits, options.aggregationUri)
+    const structure: StatusListCborDecodedStructure = new TypedMap()
 
-    return new StatusListCbor(statusList)
+    const statusList = 'statusList' in options ? options.statusList : options
+
+    if (statusList.aggregationUri) {
+      structure.set('aggregation_uri', statusList.aggregationUri)
+    }
+
+    // Already instance of StatusList, easy to construct structure
+    if (statusList instanceof StatusList) {
+      structure.set('bits', statusList.getBitsPerStatus())
+      structure.set('lst', statusList.compressStatusListToBytes())
+
+      // biome-ignore lint/complexity/noThisInStatic: this.fromDecodedStructure is intentional for subclass support
+      return this.fromDecodedStructure(structure)
+    }
+
+    // No StatusList instance yet
+    structure.set('bits', statusList.bits)
+    if (statusList.list instanceof Uint8Array) {
+      // The list is already compressed. Keep the caller's bytes rather than inflating and
+      // deflating them again, which would not reproduce their zlib stream. Inflate once to
+      // validate that the bytes are a status list we can read back.
+      StatusList.decompressStatusListFromBytes(statusList.list, statusList.bits)
+      structure.set('lst', statusList.list)
+    } else {
+      structure.set('lst', new StatusList(statusList.list, statusList.bits).compressStatusListToBytes())
+    }
+
+    // biome-ignore lint/complexity/noThisInStatic: this.fromDecodedStructure is intentional for subclass support
+    return this.fromDecodedStructure(structure)
   }
 }

--- a/packages/token-status-list/src/cbor/status-list-cwt.ts
+++ b/packages/token-status-list/src/cbor/status-list-cwt.ts
@@ -33,6 +33,17 @@ export class StatusListCwt {
   public protectedHeaders?: ProtectedHeaders
   public unprotectedHeaders?: UnprotectedHeaders
   private signatureOrTag?: Uint8Array
+
+  /**
+   * The payload bytes as received in the COSE message, kept so that verification can use them
+   * directly. RFC 9052 puts the payload into `Sig_structure`/`MAC_structure` as an opaque `bstr`, so
+   * what was signed is the exact bytes the issuer sent, not whatever we would encode the decoded
+   * payload back into. Cleared as soon as the payload is modified, since the signature over it no
+   * longer means anything at that point.
+   *
+   * @see https://datatracker.ietf.org/doc/rfc9052/#section-4.4
+   * @see https://datatracker.ietf.org/doc/rfc9052/#section-6
+   */
   private originalPayloadBytes?: Uint8Array
 
   public constructor(options: StatusListCwtOptions) {

--- a/packages/token-status-list/src/status-list.ts
+++ b/packages/token-status-list/src/status-list.ts
@@ -10,6 +10,7 @@ export class StatusList {
   private bitsPerStatus: BitsPerStatus
   public readonly totalStatuses: number
   public aggregationUri?: string
+  #isModified = false
 
   constructor(statusList: number[], bitsPerStatus: BitsPerStatus, aggregationUri?: string) {
     if (![1, 2, 4, 8].includes(bitsPerStatus)) {
@@ -36,6 +37,15 @@ export class StatusList {
     return this.bitsPerStatus
   }
 
+  /**
+   * Whether the list has been modified since it was created. Holders of a compressed encoding of
+   * this list use it to tell whether their bytes still represent it, without having to compress it
+   * again to find out.
+   */
+  get isModified(): boolean {
+    return this.#isModified
+  }
+
   /** Get the status at a specific index. */
   getStatus(index: number): StatusType {
     if (index < 0 || index >= this.totalStatuses) {
@@ -50,6 +60,7 @@ export class StatusList {
       throw new Error('Index out of bounds')
     }
     this._statusList[index] = value
+    this.#isModified = true
   }
 
   /** Compress the status list and return as raw bytes. */


### PR DESCRIPTION
## Description

Follow up to #153, and fixes the underlying issue of #132. Kept the originalPayloadBytes as that's the recommended approach to verify the signature. But at least we have safe re-encoding now of the status List

It also fixes a bug with aggreation_uri being included as undefined. It is now defined as exactOptional (undefined is not allowed) and we only set the value if it's defined.

## Related Issue

#132 

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/token-status-list`

## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have run `pnpm style:fix` to format my code
- [ ] I have run `pnpm types:check` and there are no errors
- [ ] I have run `pnpm test` and all tests pass
- [ ] I have added tests that cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [ ] I have created a changeset (if this affects published packages)

## Testing

<!-- Describe how you tested your changes -->

## Screenshots (if applicable)

<!-- Add screenshots to help explain your changes -->

## Additional Notes

<!-- Add any other context about the PR here -->


