### PR TITLE
feat(eudi-attestation-schema): enforce X509-only trusted authority verification

### DIFF
--- a/packages/eudi-attestation-schema/README.md
+++ b/packages/eudi-attestation-schema/README.md
@@ -44,6 +44,10 @@ const meta = schemaMeta()
     trustAuthority()
       .frameworkType('etsi_tl')
       .value('https://example.com/trust-lists/gym-members.jws')
+      .verificationMethod({
+        type: 'X509Certificate',
+        x509Certificate: 'MIIBczCCARmgAwIBAgIUZt2jkmAgIIiw/wpvJU/4yL7ek/YwCgYIKoZIzj0EAwIw',
+      })
       .build()
   )
   .attestationLoS('iso_18045_basic')
@@ -285,6 +289,21 @@ const meta = schemaMeta()
 | `uri` | Yes | `string` (URL) | URI of the format-specific schema |
 | `integrity` | Yes | `string` | Required W3C SRI sha256 integrity metadata for the referenced schema |
 | `meta` | Yes | format-specific object | Credential-type metadata required by the selected format |
+
+### TrustAuthority
+
+| Field | Required | Type | Description |
+|---|---|---|---|
+| `frameworkType` | Yes | `FrameworkType` | Trust framework discriminator (`etsi_tl`) |
+| `value` | Yes | `string` | URI pointing to the trust list |
+| `verificationMethod` | Yes | object | Verification material for the trust list signature |
+
+#### TrustAuthority.verificationMethod
+
+| Field | Required | Type | Description |
+|---|---|---|---|
+| `type` | Yes | `'X509Certificate'` | Verification method type |
+| `x509Certificate` | Yes | `string` | Base64-encoded DER X.509 certificate |
 
 ### Enumerations
 

--- a/packages/eudi-attestation-schema/examples/sign-and-verify.ts
+++ b/packages/eudi-attestation-schema/examples/sign-and-verify.ts
@@ -68,7 +68,16 @@ async function main() {
         .meta({ doctype_value: 'org.iso.18013.5.1.mDL' })
         .build()
     )
-    .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://trust-list.example.eu/tl.xml').build())
+    .addTrustAuthority(
+      trustAuthority()
+        .frameworkType('etsi_tl')
+        .value('https://trust-list.example.eu/tl.xml')
+        .verificationMethod({
+          type: 'X509Certificate',
+          x509Certificate: 'MIIBczCCARmgAwIBAgIUZt2jkmAgIIiw/wpvJU/4yL7ek/YwCgYIKoZIzj0EAwIw',
+        })
+        .build()
+    )
     .build()
 
   console.log('SchemaMeta:', JSON.stringify(meta, null, 2))

--- a/packages/eudi-attestation-schema/src/__tests__/builders.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/builders.test.mts
@@ -3,13 +3,31 @@ import { schemaMeta, schemaURI, trustAuthority } from '../builders'
 
 const RULEBOOK_INTEGRITY = 'sha256-cJe/IG7DijmXd2FpecyWJVnZ9EuKKprly5auxGm1uIw='
 const SCHEMA_INTEGRITY = 'sha256-M8H+reBt9Nr/s8CRicJrthAnk7UdWyTyONW0N8Z/Axw='
+const VERIFICATION_METHOD = {
+  type: 'X509Certificate' as const,
+  x509Certificate: 'MIIBczCCARmgAwIBAgIUZt2jkmAgIIiw/wpvJU/4yL7ek/YwCgYIKoZIzj0EAwIw',
+}
 
 describe('TrustAuthorityBuilder', () => {
   it('should create a trust authority with etsi_tl framework', () => {
-    const ta = trustAuthority().frameworkType('etsi_tl').value('https://example.com/trust-list.jws').build()
+    const ta = trustAuthority()
+      .frameworkType('etsi_tl')
+      .value('https://example.com/trust-list.jws')
+      .verificationMethod(VERIFICATION_METHOD)
+      .build()
 
     expect(ta.frameworkType).toBe('etsi_tl')
     expect(ta.value).toBe('https://example.com/trust-list.jws')
+  })
+
+  it('should create a trust authority with an X509 certificate verification method', () => {
+    const ta = trustAuthority()
+      .frameworkType('etsi_tl')
+      .value('https://example.com/trust-list.jws')
+      .verificationMethod(VERIFICATION_METHOD)
+      .build()
+
+    expect(ta.verificationMethod.type).toBe('X509Certificate')
   })
 
   it('should throw when frameworkType is missing', () => {
@@ -20,7 +38,13 @@ describe('TrustAuthorityBuilder', () => {
 
   it('should throw when value is missing', () => {
     expect(() => {
-      trustAuthority().frameworkType('etsi_tl').build()
+      trustAuthority().frameworkType('etsi_tl').verificationMethod(VERIFICATION_METHOD).build()
+    }).toThrow('Invalid TrustAuthority')
+  })
+
+  it('should throw when verificationMethod is missing', () => {
+    expect(() => {
+      trustAuthority().frameworkType('etsi_tl').value('https://example.com/trust-list.jws').build()
     }).toThrow('Invalid TrustAuthority')
   })
 })
@@ -103,7 +127,13 @@ describe('SchemaMetaBuilder', () => {
       .version('1.0.0')
       .rulebookURI('https://example.com/rulebook.md')
       .rulebookIntegrity(RULEBOOK_INTEGRITY)
-      .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://example.com/trust-list.jws').build())
+      .addTrustAuthority(
+        trustAuthority()
+          .frameworkType('etsi_tl')
+          .value('https://example.com/trust-list.jws')
+          .verificationMethod(VERIFICATION_METHOD)
+          .build()
+      )
       .attestationLoS('iso_18045_basic')
       .bindingType('key')
       .addSchemaURI(

--- a/packages/eudi-attestation-schema/src/__tests__/dcql.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/dcql.test.mts
@@ -4,6 +4,10 @@ import { buildDcqlFromSchemaMeta, toDcqlCredentialInput, toDcqlTrustedAuthoritie
 
 const RULEBOOK_INTEGRITY = 'sha256-cJe/IG7DijmXd2FpecyWJVnZ9EuKKprly5auxGm1uIw='
 const SCHEMA_INTEGRITY = 'sha256-M8H+reBt9Nr/s8CRicJrthAnk7UdWyTyONW0N8Z/Axw='
+const VERIFICATION_METHOD = {
+  type: 'X509Certificate' as const,
+  x509Certificate: 'MIIBczCCARmgAwIBAgIUZt2jkmAgIIiw/wpvJU/4yL7ek/YwCgYIKoZIzj0EAwIw',
+}
 
 describe('toDcqlTrustedAuthorities', () => {
   it('groups and deduplicates etsi_tl trusted authorities', () => {
@@ -22,8 +26,20 @@ describe('toDcqlTrustedAuthorities', () => {
           .meta({ vct: 'eu.example.1' })
           .build()
       )
-      .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://example.com/tl-1').build())
-      .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://example.com/tl-1').build())
+      .addTrustAuthority(
+        trustAuthority()
+          .frameworkType('etsi_tl')
+          .value('https://example.com/tl-1')
+          .verificationMethod(VERIFICATION_METHOD)
+          .build()
+      )
+      .addTrustAuthority(
+        trustAuthority()
+          .frameworkType('etsi_tl')
+          .value('https://example.com/tl-1')
+          .verificationMethod(VERIFICATION_METHOD)
+          .build()
+      )
       .build()
 
     const trustedAuthorities = toDcqlTrustedAuthorities(meta)
@@ -113,7 +129,13 @@ describe('buildDcqlFromSchemaMeta', () => {
           .meta({ doctype_value: 'org.iso.18013.5.1.mDL' })
           .build()
       )
-      .addTrustAuthority(trustAuthority().frameworkType('etsi_tl').value('https://example.com/tl-1').build())
+      .addTrustAuthority(
+        trustAuthority()
+          .frameworkType('etsi_tl')
+          .value('https://example.com/tl-1')
+          .verificationMethod(VERIFICATION_METHOD)
+          .build()
+      )
       .build()
 
     const result = buildDcqlFromSchemaMeta({

--- a/packages/eudi-attestation-schema/src/__tests__/validator.test.mts
+++ b/packages/eudi-attestation-schema/src/__tests__/validator.test.mts
@@ -3,6 +3,10 @@ import { assertValidSchemaMeta, validateSchemaMeta } from '../validator'
 
 const RULEBOOK_INTEGRITY = 'sha256-cJe/IG7DijmXd2FpecyWJVnZ9EuKKprly5auxGm1uIw='
 const SCHEMA_INTEGRITY = 'sha256-M8H+reBt9Nr/s8CRicJrthAnk7UdWyTyONW0N8Z/Axw='
+const VERIFICATION_METHOD = {
+  type: 'X509Certificate' as const,
+  x509Certificate: 'MIIBczCCARmgAwIBAgIUZt2jkmAgIIiw/wpvJU/4yL7ek/YwCgYIKoZIzj0EAwIw',
+}
 
 const validSchemaMeta = {
   id: 'https://example.com/attestations/test',
@@ -32,7 +36,13 @@ describe('validateSchemaMeta', () => {
   it('accepts etsi_tl trusted authorities', () => {
     const result = validateSchemaMeta({
       ...validSchemaMeta,
-      trustedAuthorities: [{ frameworkType: 'etsi_tl', value: 'https://example.com/trust-list.jws' }],
+      trustedAuthorities: [
+        {
+          frameworkType: 'etsi_tl',
+          value: 'https://example.com/trust-list.jws',
+          verificationMethod: VERIFICATION_METHOD,
+        },
+      ],
     })
     expect(result.valid).toBe(true)
   })
@@ -72,7 +82,15 @@ describe('validateSchemaMeta', () => {
   it('rejects invalid frameworkType in trustedAuthorities', () => {
     const result = validateSchemaMeta({
       ...validSchemaMeta,
-      trustedAuthorities: [{ frameworkType: 'aki', value: 'test' }],
+      trustedAuthorities: [{ frameworkType: 'aki', value: 'test', verificationMethod: VERIFICATION_METHOD }],
+    })
+    expect(result.valid).toBe(false)
+  })
+
+  it('rejects trustedAuthorities entries without verificationMethod', () => {
+    const result = validateSchemaMeta({
+      ...validSchemaMeta,
+      trustedAuthorities: [{ frameworkType: 'etsi_tl', value: 'https://example.com/trust-list.jws' }],
     })
     expect(result.valid).toBe(false)
   })

--- a/packages/eudi-attestation-schema/src/builders.ts
+++ b/packages/eudi-attestation-schema/src/builders.ts
@@ -34,6 +34,14 @@ export class TrustAuthorityBuilder {
   }
 
   /**
+   * Set the trust list verification method metadata
+   */
+  verificationMethod(verificationMethod: TrustAuthority['verificationMethod']): this {
+    this.data.verificationMethod = verificationMethod
+    return this
+  }
+
+  /**
    * Build the TrustAuthority object
    */
   build(): TrustAuthority {

--- a/packages/eudi-attestation-schema/src/schemas.ts
+++ b/packages/eudi-attestation-schema/src/schemas.ts
@@ -35,6 +35,21 @@ export const FrameworkTypeValues = ['etsi_tl'] as const
 
 export const FrameworkTypeSchema = z.enum(FrameworkTypeValues)
 
+export const VerificationMethodTypeValues = ['X509Certificate'] as const
+
+export const VerificationMethodTypeSchema = z.enum(VerificationMethodTypeValues)
+
+const Base64DerCertificateSchema = z
+  .string()
+  .regex(/^[A-Za-z0-9+/]+={0,2}$/, 'x509Certificate must be a base64-encoded DER certificate')
+
+const X509CertificateVerificationMethodSchema = z
+  .object({
+    type: z.literal('X509Certificate'),
+    x509Certificate: Base64DerCertificateSchema,
+  })
+  .strict()
+
 // ============================================================================
 // TrustAuthority Sub-class (Section 4.3.3)
 // ============================================================================
@@ -43,6 +58,7 @@ export const TrustAuthoritySchema = z
   .object({
     frameworkType: FrameworkTypeSchema,
     value: z.string().min(1),
+    verificationMethod: X509CertificateVerificationMethodSchema,
   })
   .strict()
 


### PR DESCRIPTION
## Description

Enforces `X509Certificate` as the only supported `verificationMethod` for `trustedAuthorities` in `@owf/eudi-attestation-schema`.

This removes `JsonWebKey` support from the trust authority verification method shape and aligns schema validation, builders, tests, docs, and examples with the X.509 identity-binding policy.

Main idea to replace and not just to add it is that only x509 will link to the identity that is managing the trust. It is not forced that the author of the schema metadata is the same entity as the trust list provider that is able to change the content of the LOTE.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/identity-common`
- [x] Other: `@owf/eudi-attestation-schema`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [x] I have updated the documentation (if applicable)
- [ ] I have created a changeset (if this affects published packages)

## Testing

- `pnpm --filter @owf/eudi-attestation-schema test`
- `pnpm run types:check`

## Screenshots (if applicable)

N/A

## Additional Notes

Scope of updates:
- schema: X.509-only verification method for trust authorities
- builders: trust authority verification method support aligned
- tests: fixtures and assertions updated to X.509-only policy
- docs/examples: `README` and sign/verify example updated