### PR TITLE
feat(eudi-wrprc): align payload with ETSI TS 119 475 Tables 7 and 10

### DIFF
--- a/.changeset/date-utils-and-validation-codes.md
+++ b/.changeset/date-utils-and-validation-codes.md
@@ -1,0 +1,8 @@
+---
+"@owf/identity-common": minor
+"@owf/eudi-wrprc": minor
+---
+
+Add `dateToSeconds`, `secondsToDate` and `nowInSeconds` to `@owf/identity-common`, and use them in `@owf/eudi-wrprc` in place of inline `* 1000` and `/ 1000` arithmetic.
+
+Type the codes that `validateWRPRCPayload` emits. `WRPRC_VALIDATION_CODES` and the `WRPRCValidationCode` union are exported, so a calling application can branch on a specific failure instead of matching message text. The `code` field stays open to strings because schema issues forward zod's own codes. `ValidationError` and `ValidationResult` are now exported as well.

--- a/.changeset/wrprc-table-10-claims.md
+++ b/.changeset/wrprc-table-10-claims.md
@@ -1,0 +1,12 @@
+---
+"@owf/eudi-wrprc": minor
+---
+
+Align the WRPRC payload with ETSI TS 119 475 v1.2.1.
+
+- Add the Table 10 optional attributes `public_body`, `exp` and `intermediary.sname`, the latter replacing `intermediary.name`. Add the `act` claim required by GEN-5.2.4-09, and `intended_use_id` from Table 9.
+- Add `iat` to `WRPRCPayloadSchema`. Table 7 lists it as a payload field, and the builder set it already, but `build()` parsed it away, so every payload it returned lost its issuance time.
+- Accept entitlements in the Annex A.2 OID form as well as the URI form (GEN-5.2.4-03). Values outside Annex A still raise a warning.
+- Validate that `exp` falls at most 12 months after `iat` (GEN-5.2.4-08), and that `act.sub` matches the intermediary identifier under intermediation (GEN-5.2.4-09).
+
+Breaking: payloads carrying `intermediary.name`, and payloads without `iat`, no longer validate.

--- a/packages/eudi-wrprc/src/__tests__/conformance.test.mts
+++ b/packages/eudi-wrprc/src/__tests__/conformance.test.mts
@@ -6,7 +6,7 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { validateWRPRCPayload, WRP_ENTITLEMENTS, wrprc } from '../index'
+import { validateWRPRCPayload, WRP_ENTITLEMENTS, WRPRC_VALIDATION_CODES, wrprc } from '../index'
 
 const base = () =>
   wrprc()
@@ -71,5 +71,17 @@ describe('Table 10 fields', () => {
     const payload = base().publicBody(true).intendedUseId('use-123').build()
     expect(payload.public_body).toBe(true)
     expect(payload.intended_use_id).toBe('use-123')
+  })
+})
+
+describe('validation codes', () => {
+  it('exposes codes a calling application can branch on', () => {
+    const result = validateWRPRCPayload(
+      base()
+        .expiresAt(1_700_000_000 + 400 * 24 * 3600)
+        .build()
+    )
+
+    expect(result.errors.map((e) => e.code)).toContain(WRPRC_VALIDATION_CODES.EXP_TOO_LATE)
   })
 })

--- a/packages/eudi-wrprc/src/__tests__/conformance.test.mts
+++ b/packages/eudi-wrprc/src/__tests__/conformance.test.mts
@@ -1,0 +1,75 @@
+/**
+ * Conformance tests for the spec-alignment fixes:
+ *  - srv_description / purpose serialize localized text as `value` (Tables 7/9)
+ *  - entitlements accept OID form as well as URI (GEN-5.2.4-03)
+ *  - Table 10 fields: exp (<= 12 months after iat), intermediary{sub,sname}, act
+ */
+
+import { describe, expect, it } from 'vitest'
+import { validateWRPRCPayload, WRP_ENTITLEMENTS, wrprc } from '../index'
+
+const base = () =>
+  wrprc()
+    .name('Example')
+    .legalName('Example N.V.')
+    .identifier('LEINL-529900T8BM49AURSDO55')
+    .country('NL')
+    .registryUri('https://registry.test/wrp')
+    .addEntitlement(WRP_ENTITLEMENTS.SERVICE_PROVIDER)
+    .issuedAt(1_700_000_000)
+
+describe('localized values serialize as { lang, value }', () => {
+  it('emits value (not content) for srv_description and purpose', () => {
+    const payload = base().serviceDescription('Onboarding', 'en').addPurpose('Verify age', 'en').build()
+
+    expect(payload.srv_description?.[0][0]).toEqual({ lang: 'en', value: 'Onboarding' })
+    expect(payload.purpose?.[0]).toEqual({ lang: 'en', value: 'Verify age' })
+  })
+})
+
+describe('entitlements accept OID form', () => {
+  it('validates an entitlement given as an OID', () => {
+    const payload = base().entitlements(['0.4.0.19475.1.1']).build()
+    expect(validateWRPRCPayload(payload).valid).toBe(true)
+  })
+})
+
+describe('Table 10 fields', () => {
+  it('accepts exp within 12 months of iat', () => {
+    const payload = base()
+      .expiresAt(1_700_000_000 + 200 * 24 * 3600)
+      .build()
+    expect(validateWRPRCPayload(payload).valid).toBe(true)
+  })
+
+  it('rejects exp more than 12 months after iat', () => {
+    const payload = base()
+      .expiresAt(1_700_000_000 + 400 * 24 * 3600)
+      .build()
+    const result = validateWRPRCPayload(payload)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.code === 'exp_too_late')).toBe(true)
+  })
+
+  it('requires act.sub to match intermediary.sub', () => {
+    const ok = base()
+      .intermediary({ sub: 'LEINL-INTERMEDIARY', sname: 'Intermediary BV' })
+      .act({ sub: 'LEINL-INTERMEDIARY' })
+      .build()
+    expect(validateWRPRCPayload(ok).valid).toBe(true)
+
+    const mismatch = base()
+      .intermediary({ sub: 'LEINL-INTERMEDIARY', sname: 'Intermediary BV' })
+      .act({ sub: 'LEINL-OTHER' })
+      .build()
+    const result = validateWRPRCPayload(mismatch)
+    expect(result.valid).toBe(false)
+    expect(result.errors.some((e) => e.code === 'act_intermediary_mismatch')).toBe(true)
+  })
+
+  it('carries public_body and intended_use_id through the builder', () => {
+    const payload = base().publicBody(true).intendedUseId('use-123').build()
+    expect(payload.public_body).toBe(true)
+    expect(payload.intended_use_id).toBe('use-123')
+  })
+})

--- a/packages/eudi-wrprc/src/builders.ts
+++ b/packages/eudi-wrprc/src/builders.ts
@@ -6,6 +6,7 @@
  * @see https://www.etsi.org/deliver/etsi_ts/119400_119499/119475/01.02.01_60/ts_119475v010201p.pdf
  */
 
+import { dateToSeconds, nowInSeconds } from '@owf/identity-common'
 import type { z } from 'zod'
 import { ENTITLEMENT_SERVICE_PROVIDER, type WRP_ENTITLEMENTS } from './entitlements'
 import { WRPRCPayloadSchema } from './schemas'
@@ -197,7 +198,7 @@ export class WRPRCBuilder {
    * If not set, will default to current time when building
    */
   issuedAt(timestamp: number | Date): this {
-    this.payload.iat = typeof timestamp === 'number' ? timestamp : Math.floor(timestamp.getTime() / 1000)
+    this.payload.iat = typeof timestamp === 'number' ? timestamp : dateToSeconds(timestamp)
     return this
   }
 
@@ -296,7 +297,7 @@ export class WRPRCBuilder {
    * Set the expiry timestamp (Table 10); must be at most 12 months after iat
    */
   expiresAt(timestamp: number | Date): this {
-    this.payload.exp = typeof timestamp === 'number' ? timestamp : Math.floor(timestamp.getTime() / 1000)
+    this.payload.exp = typeof timestamp === 'number' ? timestamp : dateToSeconds(timestamp)
     return this
   }
 
@@ -316,7 +317,7 @@ export class WRPRCBuilder {
   build(): WRPRCPayload {
     // Set default iat if not provided
     if (!this.payload.iat) {
-      this.payload.iat = Math.floor(Date.now() / 1000)
+      this.payload.iat = nowInSeconds()
     }
 
     const result = WRPRCPayloadSchema.safeParse(this.payload)

--- a/packages/eudi-wrprc/src/builders.ts
+++ b/packages/eudi-wrprc/src/builders.ts
@@ -10,6 +10,7 @@ import type { z } from 'zod'
 import { ENTITLEMENT_SERVICE_PROVIDER, type WRP_ENTITLEMENTS } from './entitlements'
 import { WRPRCPayloadSchema } from './schemas'
 import type {
+  Act,
   Claim,
   Credential,
   Intermediary,
@@ -26,9 +27,7 @@ import { WRPRCException } from './wrprc-exception'
 // Partial Payload Type
 // ============================================================================
 
-type PartialWRPRCPayload = Partial<z.input<typeof WRPRCPayloadSchema>> & {
-  iat?: number
-}
+type PartialWRPRCPayload = Partial<z.input<typeof WRPRCPayloadSchema>>
 
 // ============================================================================
 // WRPRC Payload Builder
@@ -274,6 +273,38 @@ export class WRPRCBuilder {
    */
   intermediary(intermediary: Intermediary): this {
     this.payload.intermediary = intermediary
+    return this
+  }
+
+  /**
+   * Set the actor claim under intermediation (Table 10, GEN-5.2.4-09)
+   */
+  act(act: Act): this {
+    this.payload.act = act
+    return this
+  }
+
+  /**
+   * Mark the WRP as a public sector body (Table 10)
+   */
+  publicBody(value: boolean): this {
+    this.payload.public_body = value
+    return this
+  }
+
+  /**
+   * Set the expiry timestamp (Table 10); must be at most 12 months after iat
+   */
+  expiresAt(timestamp: number | Date): this {
+    this.payload.exp = typeof timestamp === 'number' ? timestamp : Math.floor(timestamp.getTime() / 1000)
+    return this
+  }
+
+  /**
+   * Set the intended-use identifier, used to fetch the intended use from the registry (Table 9)
+   */
+  intendedUseId(id: string): this {
+    this.payload.intended_use_id = id
     return this
   }
 

--- a/packages/eudi-wrprc/src/index.ts
+++ b/packages/eudi-wrprc/src/index.ts
@@ -64,6 +64,7 @@ export type {
   WRPRCPayload,
 } from './types'
 // Validators
+export type { ValidationError, ValidationResult, WRPRCValidationCode } from './validator'
 export {
   assertValidWRPRC,
   assertValidWRPRCPayload,
@@ -74,6 +75,7 @@ export {
   validateWRPRC,
   validateWRPRCJWTHeader,
   validateWRPRCPayload,
+  WRPRC_VALIDATION_CODES,
 } from './validator'
 
 // Exception

--- a/packages/eudi-wrprc/src/index.ts
+++ b/packages/eudi-wrprc/src/index.ts
@@ -29,6 +29,7 @@ export {
 } from './entitlements'
 // Schemas
 export {
+  ActSchema,
   ClaimSchema,
   CredentialSchema,
   IntermediarySchema,
@@ -45,6 +46,7 @@ export {
 export { createWRPRCPayload, decodeWRPRC, parseWRPRC, signWRPRC } from './signer'
 // Types
 export type {
+  Act,
   Claim,
   Credential,
   Intermediary,

--- a/packages/eudi-wrprc/src/schemas.ts
+++ b/packages/eudi-wrprc/src/schemas.ts
@@ -79,13 +79,23 @@ export const StatusSchema = z.object({
 })
 
 /**
- * Intermediary information when WRP acts through an intermediary
+ * Intermediary information when WRP acts through an intermediary (Table 10).
+ * The intermediary's semantic identifier comes from its own WRPAC.
  */
 export const IntermediarySchema = z.object({
-  /** Identifier of the intermediary */
+  /** Semantic identifier of the intermediary (from the intermediary's WRPAC) */
   sub: z.string().min(1),
-  /** Name of the intermediary */
-  name: z.string().min(1),
+  /** Common name of the intermediary */
+  sname: z.string().min(1),
+})
+
+/**
+ * The "actor" claim (Table 10, GEN-5.2.4-09): under intermediation, identifies
+ * the intermediary acting on behalf of the subject. `act.sub` matches `intermediary.sub`.
+ */
+export const ActSchema = z.object({
+  /** Semantic identifier of the acting intermediary */
+  sub: z.string().min(1),
 })
 
 // ============================================================================
@@ -117,11 +127,11 @@ export const WRPRCPayloadSchema = z.object({
   /** URL pointing to the national registry API endpoint */
   registry_uri: z.url(),
 
-  /** Descriptions of the services provided by the WRP */
+  /** Descriptions of the services provided by the WRP (array of arrays of localized values) */
   srv_description: z.array(z.array(MultiLangStringSchema)).optional(),
 
-  /** List of entitlements assigned to the WRP */
-  entitlements: z.array(z.url()).min(1),
+  /** List of entitlements assigned to the WRP (Annex A.2 URI or OID form) */
+  entitlements: z.array(z.string().min(1)).min(1),
 
   /** URL to the WRP's privacy policy */
   privacy_policy: z.url().optional(),
@@ -141,10 +151,13 @@ export const WRPRCPayloadSchema = z.object({
   /** URL to the certificate policy and practice statement */
   certificate_policy: z.url().optional(),
 
+  /** Issuance time as a Unix timestamp (Table 7) */
+  iat: z.number().int().positive(),
+
   /** Status list for WRPRC validity */
   status: StatusSchema.optional(),
 
-  /** Purpose of the intended data processing */
+  /** Purpose of the intended data processing (localized values) */
   purpose: z.array(MultiLangStringSchema).optional(),
 
   /** Set of credentials intended to be requested by the WRP */
@@ -153,8 +166,20 @@ export const WRPRCPayloadSchema = z.object({
   /** Set of credentials issued by the WRP (for attestation providers) */
   provides_attestations: z.union([z.array(CredentialSchema), z.array(z.string())]).optional(),
 
-  /** Intermediary information when WRP acts through an intermediary */
+  /** Intermediary information when WRP acts through an intermediary (Table 10) */
   intermediary: IntermediarySchema.optional(),
+
+  /** Actor claim under intermediation (Table 10, GEN-5.2.4-09) */
+  act: ActSchema.optional(),
+
+  /** Whether the WRP is a public sector body (Table 10) */
+  public_body: z.boolean().optional(),
+
+  /** Expiry as a Unix timestamp; at most 12 months after `iat` (Table 10, GEN-5.2.4-08) */
+  exp: z.number().int().positive().optional(),
+
+  /** Identifier of the intended use, present only if provided by the registry (Table 9) */
+  intended_use_id: z.string().min(1).optional(),
 })
 
 // ============================================================================

--- a/packages/eudi-wrprc/src/signer.ts
+++ b/packages/eudi-wrprc/src/signer.ts
@@ -7,7 +7,7 @@
  */
 
 import { pemToDer } from '@owf/crypto'
-import { base64urlEncode, decodeJwt } from '@owf/identity-common'
+import { base64urlEncode, decodeJwt, nowInSeconds } from '@owf/identity-common'
 import type { SignedWRPRC, SignOptions, WRPRCJWTHeader, WRPRCPayload } from './types'
 import { assertValidWRPRCPayload } from './validator'
 import { WRPRCException } from './wrprc-exception'
@@ -46,7 +46,7 @@ export async function signWRPRC(options: SignOptions): Promise<SignedWRPRC> {
     typ: 'rc-wrp+jwt',
     alg: algorithm,
     x5c,
-    iat: Math.floor(Date.now() / 1000),
+    iat: nowInSeconds(),
     ...(keyId && { kid: keyId }),
   }
 

--- a/packages/eudi-wrprc/src/types.ts
+++ b/packages/eudi-wrprc/src/types.ts
@@ -10,6 +10,7 @@
 import type { Signer } from '@owf/crypto'
 import type { z } from 'zod'
 import type {
+  ActSchema,
   ClaimSchema,
   CredentialSchema,
   IntermediarySchema,
@@ -54,6 +55,9 @@ export type Status = z.infer<typeof StatusSchema>
 
 /** Intermediary information */
 export type Intermediary = z.infer<typeof IntermediarySchema>
+
+/** Actor claim under intermediation (Table 10) */
+export type Act = z.infer<typeof ActSchema>
 
 // ============================================================================
 // WRPRC Document Types

--- a/packages/eudi-wrprc/src/validator.ts
+++ b/packages/eudi-wrprc/src/validator.ts
@@ -6,6 +6,7 @@
  * @see https://www.etsi.org/deliver/etsi_ts/119400_119499/119475/01.02.01_60/ts_119475v010201p.pdf
  */
 
+import { secondsToDate } from '@owf/identity-common'
 import { ALL_ENTITLEMENTS, ALL_PSP_SUB_ENTITLEMENTS, ATTESTATION_PROVIDER_ENTITLEMENTS } from './entitlements'
 import {
   LegalPersonSubjectSchema,
@@ -21,6 +22,39 @@ import { WRPRCException } from './wrprc-exception'
 // ============================================================================
 
 /**
+ * Codes for the semantic checks this validator performs, beyond schema parsing.
+ *
+ * Exposed so a calling application can branch on a specific failure rather than
+ * matching on message text. Requirement identifiers from ETSI TS 119 475 v1.2.1
+ * are given where a code maps to one.
+ */
+export const WRPRC_VALIDATION_CODES = {
+  /** No entitlement present (GEN-5.2.4-03) */
+  MISSING_ENTITLEMENT: 'missing_entitlement',
+  /** Sub-entitlement present without its base entitlement (GEN-5.2.4-04) */
+  MISSING_BASE_ENTITLEMENT: 'missing_base_entitlement',
+  /** Entitlement outside Annex A, which may be a national or EU extension */
+  UNKNOWN_ENTITLEMENT: 'unknown_entitlement',
+  /** Attestation provider without provides_attestations (GEN-5.2.4-05) */
+  MISSING_PROVIDES_ATTESTATIONS: 'missing_provides_attestations',
+  /** sub does not follow the semantic identifier format of clause 5.1 */
+  INVALID_SEMANTIC_IDENTIFIER: 'invalid_semantic_identifier',
+  /** sub parses but deviates from the expected identifier shape */
+  IDENTIFIER_FORMAT_WARNING: 'identifier_format_warning',
+  /** exp more than 12 months after iat (GEN-5.2.4-08) */
+  EXP_TOO_LATE: 'exp_too_late',
+  /** exp at or before iat */
+  EXP_BEFORE_IAT: 'exp_before_iat',
+  /** intermediary present without act (GEN-5.2.4-09) */
+  MISSING_ACT: 'missing_act',
+  /** act.sub does not match intermediary.sub (GEN-5.2.4-09) */
+  ACT_INTERMEDIARY_MISMATCH: 'act_intermediary_mismatch',
+} as const
+
+/** A semantic validation code emitted by this validator */
+export type WRPRCValidationCode = (typeof WRPRC_VALIDATION_CODES)[keyof typeof WRPRC_VALIDATION_CODES]
+
+/**
  * A single validation error
  */
 export interface ValidationError {
@@ -28,8 +62,11 @@ export interface ValidationError {
   path: string[]
   /** Error message */
   message: string
-  /** Error code */
-  code: string
+  /**
+   * Error code. Either a `WRPRCValidationCode` from the semantic checks, or a zod issue
+   * code forwarded from schema parsing, so the string stays open for the latter.
+   */
+  code: WRPRCValidationCode | (string & {})
 }
 
 /**
@@ -78,7 +115,7 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
         warnings.push({
           path: ['entitlements'],
           message: `Unknown entitlement URI: ${entitlement}. This may be a national or EU-defined extension.`,
-          code: 'unknown_entitlement',
+          code: WRPRC_VALIDATION_CODES.UNKNOWN_ENTITLEMENT,
         })
       }
     }
@@ -89,7 +126,7 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
     errors.push({
       path: ['entitlements'],
       message: 'At least one entitlement must be specified (GEN-5.2.4-03)',
-      code: 'missing_entitlement',
+      code: WRPRC_VALIDATION_CODES.MISSING_ENTITLEMENT,
     })
   }
 
@@ -104,7 +141,7 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
     errors.push({
       path: ['entitlements'],
       message: 'Service provider sub-entitlements require Service_Provider entitlement (GEN-5.2.4-04)',
-      code: 'missing_base_entitlement',
+      code: WRPRC_VALIDATION_CODES.MISSING_BASE_ENTITLEMENT,
     })
   }
 
@@ -117,7 +154,7 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
       path: ['provides_attestations'],
       message:
         'Attestation providers should include provides_attestations field (GEN-5.2.4-05). This is recommended but not required.',
-      code: 'missing_provides_attestations',
+      code: WRPRC_VALIDATION_CODES.MISSING_PROVIDES_ATTESTATIONS,
     })
   }
 
@@ -127,26 +164,26 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
     errors.push({
       path: ['sub'],
       message: subResult.message,
-      code: 'invalid_semantic_identifier',
+      code: WRPRC_VALIDATION_CODES.INVALID_SEMANTIC_IDENTIFIER,
     })
   }
 
   // GEN-5.2.4-08: exp must be at most 12 months after iat
   if (typeof validPayload.exp === 'number') {
-    const maxExp = new Date(validPayload.iat * 1000)
+    const maxExp = secondsToDate(validPayload.iat)
     maxExp.setUTCFullYear(maxExp.getUTCFullYear() + 1)
-    if (validPayload.exp * 1000 > maxExp.getTime()) {
+    if (secondsToDate(validPayload.exp) > maxExp) {
       errors.push({
         path: ['exp'],
         message: 'exp must be at most 12 months after iat (GEN-5.2.4-08)',
-        code: 'exp_too_late',
+        code: WRPRC_VALIDATION_CODES.EXP_TOO_LATE,
       })
     }
     if (validPayload.exp <= validPayload.iat) {
       errors.push({
         path: ['exp'],
         message: 'exp must be after iat',
-        code: 'exp_before_iat',
+        code: WRPRC_VALIDATION_CODES.EXP_BEFORE_IAT,
       })
     }
   }
@@ -157,13 +194,13 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
       errors.push({
         path: ['act'],
         message: 'act claim is required when an intermediary is present (GEN-5.2.4-09)',
-        code: 'missing_act',
+        code: WRPRC_VALIDATION_CODES.MISSING_ACT,
       })
     } else if (validPayload.act.sub !== validPayload.intermediary.sub) {
       errors.push({
         path: ['act', 'sub'],
         message: 'act.sub must match intermediary.sub (GEN-5.2.4-09)',
-        code: 'act_intermediary_mismatch',
+        code: WRPRC_VALIDATION_CODES.ACT_INTERMEDIARY_MISMATCH,
       })
     }
   }
@@ -263,7 +300,7 @@ export function validateLegalPersonWRPRC(payload: unknown): ValidationResult {
         path: ['sub'],
         message:
           'Legal person identifier should follow format: PREFIX + COUNTRY + "-" + ID (e.g., "LEIXG-529900T8BM49AURSDO55")',
-        code: 'identifier_format_warning',
+        code: WRPRC_VALIDATION_CODES.IDENTIFIER_FORMAT_WARNING,
       })
     }
   }
@@ -299,7 +336,7 @@ export function validateNaturalPersonWRPRC(payload: unknown): ValidationResult {
         path: ['sub'],
         message:
           'Natural person identifier should follow format: PREFIX + COUNTRY + "-" + ID (e.g., "TINIT-RSSMRA85T10A562S")',
-        code: 'identifier_format_warning',
+        code: WRPRC_VALIDATION_CODES.IDENTIFIER_FORMAT_WARNING,
       })
     }
   }

--- a/packages/eudi-wrprc/src/validator.ts
+++ b/packages/eudi-wrprc/src/validator.ts
@@ -131,6 +131,43 @@ export function validateWRPRCPayload(payload: unknown): ValidationResult {
     })
   }
 
+  // GEN-5.2.4-08: exp must be at most 12 months after iat
+  if (typeof validPayload.exp === 'number') {
+    const maxExp = new Date(validPayload.iat * 1000)
+    maxExp.setUTCFullYear(maxExp.getUTCFullYear() + 1)
+    if (validPayload.exp * 1000 > maxExp.getTime()) {
+      errors.push({
+        path: ['exp'],
+        message: 'exp must be at most 12 months after iat (GEN-5.2.4-08)',
+        code: 'exp_too_late',
+      })
+    }
+    if (validPayload.exp <= validPayload.iat) {
+      errors.push({
+        path: ['exp'],
+        message: 'exp must be after iat',
+        code: 'exp_before_iat',
+      })
+    }
+  }
+
+  // GEN-5.2.4-09: under intermediation, act.sub must match intermediary.sub
+  if (validPayload.intermediary) {
+    if (!validPayload.act) {
+      errors.push({
+        path: ['act'],
+        message: 'act claim is required when an intermediary is present (GEN-5.2.4-09)',
+        code: 'missing_act',
+      })
+    } else if (validPayload.act.sub !== validPayload.intermediary.sub) {
+      errors.push({
+        path: ['act', 'sub'],
+        message: 'act.sub must match intermediary.sub (GEN-5.2.4-09)',
+        code: 'act_intermediary_mismatch',
+      })
+    }
+  }
+
   return { valid: errors.length === 0, errors, warnings }
 }
 

--- a/packages/identity-common/src/__tests__/dates.test.mts
+++ b/packages/identity-common/src/__tests__/dates.test.mts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { dateToSeconds, nowInSeconds, secondsToDate } from '../../src'
+
+describe('dates', () => {
+  it('should round-trip a whole-second date', () => {
+    const date = new Date('2026-03-01T12:00:00.000Z')
+    expect(secondsToDate(dateToSeconds(date))).toEqual(date)
+  })
+
+  it('should truncate sub-second precision rather than round it', () => {
+    expect(dateToSeconds(new Date('2026-03-01T12:00:00.999Z'))).toBe(
+      dateToSeconds(new Date('2026-03-01T12:00:00.000Z'))
+    )
+  })
+
+  it('should convert seconds to a date', () => {
+    expect(secondsToDate(1_700_000_000).toISOString()).toBe('2023-11-14T22:13:20.000Z')
+  })
+
+  it('should return the current time in seconds', () => {
+    const before = Math.floor(Date.now() / 1000)
+    const now = nowInSeconds()
+    expect(now).toBeGreaterThanOrEqual(before)
+    expect(now).toBeLessThanOrEqual(Math.floor(Date.now() / 1000))
+  })
+})

--- a/packages/identity-common/src/dates.ts
+++ b/packages/identity-common/src/dates.ts
@@ -1,0 +1,19 @@
+/**
+ * Conversions between JavaScript `Date` values and the Unix timestamps in seconds
+ * used by JWT, CWT and COSE claims such as `iat`, `exp` and `nbf`.
+ */
+
+/**
+ * Convert a `Date` to a Unix timestamp in seconds, truncating sub-second precision.
+ */
+export const dateToSeconds = (date: Date): number => Math.floor(date.getTime() / 1000)
+
+/**
+ * Convert a Unix timestamp in seconds to a `Date`.
+ */
+export const secondsToDate = (seconds: number): Date => new Date(seconds * 1000)
+
+/**
+ * The current time as a Unix timestamp in seconds.
+ */
+export const nowInSeconds = (): number => dateToSeconds(new Date())

--- a/packages/identity-common/src/index.ts
+++ b/packages/identity-common/src/index.ts
@@ -1,4 +1,5 @@
 export * from './base64url'
+export * from './dates'
 export * from './decode-jwt'
 export * from './hex'
 export * from './identity-common-exception'


### PR DESCRIPTION
## What

Brings `WRPRCPayloadSchema` in line with ETSI TS 119 475 v1.2.1, clause 5.2.4.

- Table 10 optional attributes: `public_body`, `exp`, and `intermediary.sname`, which replaces `intermediary.name`. Table 10 defines `sname` as the commonName of the intermediary as specified by the intermediary WRPAC.
- `act`, required by GEN-5.2.4-09 when the WRP acts through an intermediary, and `intended_use_id` from Table 9.
- `iat` becomes part of the payload schema.
- `entitlements` accepts the Annex A.2 OID form alongside the URI form (GEN-5.2.4-03). Values outside Annex A still raise a warning rather than an error.
- Two conformance rules in `validateWRPRCPayload`: `exp` at most 12 months after `iat` (GEN-5.2.4-08), and `act.sub` matching the intermediary identifier whenever an intermediary is present (GEN-5.2.4-09).

Each claim carries a builder method: `publicBody()`, `expiresAt()`, `act()`, `intendedUseId()`.

## Note on Annex C

The informative example in Annex C still shows `"intermediary": { "sub": ..., "name": ... }`, which contradicts normative Table 10. Annex C looks stale rather than authoritative: v1.1.1 Table 10 had no `intermediary` field at all, only `act` with nested `sub.id` and `sub.name`, and v1.2.1 flattened that into `intermediary.sub` and `intermediary.sname` while moving the actor requirement into GEN-5.2.4-09. The Annex C snippet was not updated with the table and still omits `act` entirely. This PR follows the normative table.

## Why `iat` moved into the payload schema

Table 7 lists `iat` as a payload field. `WRPRCBuilder` already set `payload.iat`, and worked around the claim's absence from the schema with `Partial<z.input<...>> & { iat?: number }`. Since `build()` returns `WRPRCPayloadSchema.safeParse(...).data`, zod stripped the claim on the way out, so every payload the builder returned came back without an issuance time. The workaround type is gone.

## Breaking changes

- Payloads carrying `intermediary.name` no longer validate. Use `sname`.
- Payloads without `iat` no longer validate.

## Tests

`conformance.test.mts` covers the Table 10 claims, the OID entitlement form, and both validation rules. `pnpm ci:check` is green: 47 tests in this package, 11 packages in total.
