### PR TITLE
feat(eudi-wrprc): add optional jti claim to the payload

### DIFF
--- a/.changeset/wrprc-jti-identifier.md
+++ b/.changeset/wrprc-jti-identifier.md
@@ -1,0 +1,8 @@
+---
+"@owf/eudi-wrprc": minor
+---
+
+Add an optional `jti` claim to the WRPRC payload, so a certificate can be referenced by an identifier.
+
+- `WRPRCPayloadSchema` accepts an optional non-empty `jti` (RFC 7519). ETSI TS 119 475 does not define the claim, so it is never generated: a payload built without one carries no identifier, and payloads issued elsewhere without one stay valid.
+- New builder method `certificateId(id)` sets `jti`, for issuers that have their own identifier scheme. Pass `crypto.randomUUID()` for a random one.

--- a/packages/eudi-wrprc/src/__tests__/eudi-wrprc.test.mts
+++ b/packages/eudi-wrprc/src/__tests__/eudi-wrprc.test.mts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 import {
   createLegalPersonWRPRC,
   createNaturalPersonWRPRC,
+  createWRPRCPayload,
   credential,
   hasAttestationProviderEntitlement,
   isLegalPersonWRPRC,
@@ -93,6 +94,28 @@ describe('WRPRCPayloadSchema', () => {
     }
     const result = WRPRCPayloadSchema.safeParse(payload)
     expect(result.success).toBe(true)
+  })
+
+  it('should accept a payload with a jti', () => {
+    const jti_uuid = '0c1f7a2e-3d4b-4c5a-8e9f-1a2b3c4d5e6f'
+    const payload = { ...validLegalPersonPayload, jti: jti_uuid }
+    const result = WRPRCPayloadSchema.safeParse(payload)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.jti).toBe(jti_uuid)
+  })
+
+  it('should accept a payload without a jti', () => {
+    const result = WRPRCPayloadSchema.safeParse(validLegalPersonPayload)
+
+    expect(result.success).toBe(true)
+    expect(result.data?.jti).toBeUndefined()
+  })
+
+  it('should reject an empty jti', () => {
+    const payload = { ...validLegalPersonPayload, jti: '' }
+    const result = WRPRCPayloadSchema.safeParse(payload)
+    expect(result.success).toBe(false)
   })
 })
 
@@ -283,6 +306,34 @@ describe('WRPRCBuilder', () => {
     expect(payload.sub_fn).toBe('Rossi')
   })
 
+  it('should omit jti when no certificate id is set', () => {
+    const payload = wrprc()
+      .name('Test Service')
+      .legalName('Test Inc.')
+      .identifier('LEIXG-529900T8BM49AURSDO55')
+      .country('DE')
+      .registryUri('https://registry.example.com/api')
+      .addEntitlement(WRP_ENTITLEMENTS.SERVICE_PROVIDER)
+      .build()
+
+    expect(payload.jti).toBeUndefined()
+  })
+
+  it('should preserve an explicitly set certificate id', () => {
+    const jti_uuid = 'urn:uuid:0c1f7a2e-3d4b-4c5a-8e9f-1a2b3c4d5e6f'
+    const payload = wrprc()
+      .name('Test Service')
+      .legalName('Test Inc.')
+      .identifier('LEIXG-529900T8BM49AURSDO55')
+      .country('DE')
+      .registryUri('https://registry.example.com/api')
+      .addEntitlement(WRP_ENTITLEMENTS.SERVICE_PROVIDER)
+      .certificateId(jti_uuid)
+      .build()
+
+    expect(payload.jti).toBe(jti_uuid)
+  })
+
   it('should add multiple entitlements', () => {
     const payload = wrprc()
       .name('Test')
@@ -416,6 +467,18 @@ describe('Factory Functions', () => {
 
       expect(payload.sub_gn).toBe('Maria')
       expect(payload.sub_fn).toBe('Rossi')
+    })
+  })
+
+  describe('createWRPRCPayload', () => {
+    it('should carry a provided jti through', () => {
+      const jti_uuid = 'urn:uuid:0c1f7a2e-3d4b-4c5a-8e9f-1a2b3c4d5e6f'
+      const payload = createWRPRCPayload({
+        ...validLegalPersonPayload,
+        jti: jti_uuid,
+      })
+
+      expect(payload.jti).toBe(jti_uuid)
     })
   })
 })

--- a/packages/eudi-wrprc/src/builders.ts
+++ b/packages/eudi-wrprc/src/builders.ts
@@ -194,6 +194,17 @@ export class WRPRCBuilder {
   }
 
   /**
+   * Set the unique identifier of the certificate (`jti`)
+   * If not set, the payload carries no identifier
+   *
+   * @param id - Identifier from the issuing registry's own scheme.
+   */
+  certificateId(id: string): this {
+    this.payload.jti = id
+    return this
+  }
+
+  /**
    * Set the issued-at timestamp (Unix timestamp)
    * If not set, will default to current time when building
    */

--- a/packages/eudi-wrprc/src/schemas.ts
+++ b/packages/eudi-wrprc/src/schemas.ts
@@ -151,6 +151,14 @@ export const WRPRCPayloadSchema = z.object({
   /** URL to the certificate policy and practice statement */
   certificate_policy: z.url().optional(),
 
+  /**
+   * Unique identifier of this WRPRC (RFC 7519 `jti`).
+   *
+   * Not listed in ETSI TS 119 475, which leaves the certificate without an identifier
+   * to reference it by. Optional so that WRPRCs issued without one still validate.
+   */
+  jti: z.string().min(1).optional(),
+
   /** Issuance time as a Unix timestamp (Table 7) */
   iat: z.number().int().positive(),
 


### PR DESCRIPTION
## Description

A WRPRC carried no identifier of its own, so there was no way to easily reference a specific certificate, e.g. in a revocation record, an audit log, or similar.

This adds an optional `jti` claim (RFC 7519) to the WRPRC payload.

ETSI TS 119 475 does not define this claim, so it is deliberately **never generated**. A payload built without `certificateId()` carries no `jti`, and nothing non-standard ends up in a signed certificate unless the issuer asks for it. Issuers pass an identifier from their own registry scheme, or `crypto.randomUUID()` if they just want a random one. Certificates issued elsewhere without a `jti` continue to validate.

The change is purely additive — no existing behaviour, signature, or output changes.

## Related Issue

<!-- Link to the issue this PR addresses (if applicable) -->

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactoring (no functional changes)
- [ ] 📦 New package

## Packages Affected

- [ ] `@owf/identity-common`
- [x] Other: `@owf/eudi-wrprc`

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run `pnpm style:fix` to format my code
- [x] I have run `pnpm types:check` and there are no errors
- [x] I have run `pnpm test` and all tests pass
- [x] I have added tests that cover my changes (if applicable)
- [ ] I have updated the documentation (if applicable)
- [x] I have created a changeset (if this affects published packages)

## Testing

Added unit tests in `packages/eudi-wrprc/src/__tests__/eudi-wrprc.test.mts`:

- `WRPRCPayloadSchema` accepts a payload with a `jti`, accepts one without, and
  rejects an empty-string `jti`.
- `WRPRCBuilder` omits `jti` when no certificate id is set, and preserves an
  explicitly set one.
- `createWRPRCPayload` carries a provided `jti` through.

Full suite: `pnpm test` — 54 tests pass in `@owf/eudi-wrprc` (47 in
`eudi-wrprc.test.mts`, 7 in `conformance.test.mts`), 11/11 turbo tasks green
across the repo. `pnpm types:check`, `pnpm style:check` and `pnpm md:check` are
also clean.

## Screenshots (if applicable)

N/A

## Additional Notes
